### PR TITLE
Upgrade to PyTorch 2.9.0 stable and remove LD_LIBRARY_PATH hack

### DIFF
--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -1,24 +1,26 @@
 # ==============================================================================
-# PyTorch Nightly CPU-Only - For Systems Without NVIDIA GPU
+# PyTorch 2.9.0 CPU-Only - For Systems Without NVIDIA GPU
 # ==============================================================================
 #
-# For CPU-only systems, AMD GPUs, or any non-NVIDIA hardware
+# USING STABLE PYTORCH 2.9.0:
+# - PyTorch 2.7+ includes Blackwell architecture support
+# - Using stable release for reliability and ecosystem compatibility
+# - Same version as NVIDIA setup for consistency across all hardware
 #
-# WHY NIGHTLY:
-# - Used to match NVIDIA version for consistency across all hardware
-# - Ensures same PyTorch version for both GPU and CPU installations
-# - Stable PyTorch would work fine for CPU, but nightly used for uniformity
+# FOR CPU-ONLY SYSTEMS:
+# - Systems without NVIDIA GPU
+# - AMD GPUs (not supported for GPU acceleration)
+# - Any non-NVIDIA hardware
 #
-# WHEN TO SWITCH TO STABLE:
-# - Once PyTorch 2.6+ stable is released (when NVIDIA systems can also switch)
-# - Expected: Q1-Q2 2026
-# - Then replace with: torch>=2.6.0 torchvision>=0.17.0 torchaudio>=2.6.0
-# - And remove --extra-index-url (use default PyPI)
+# NOTE:
+# - PyTorch 2.7+ stable works perfectly for CPU-only systems
+# - CPU-only builds don't need CUDA, so no special CUDA version required
 #
 # ==============================================================================
 
-# PyTorch nightly CPU version
---extra-index-url https://download.pytorch.org/whl/nightly/cpu
-torch --pre
-torchvision --pre
-torchaudio --pre
+# PyTorch 2.9.0 stable CPU version
+--index-url https://download.pytorch.org/whl/cpu
+
+torch==2.9.0
+torchvision==0.24.0
+torchaudio==2.9.0

--- a/requirements-nvidia.txt
+++ b/requirements-nvidia.txt
@@ -1,26 +1,26 @@
 # ==============================================================================
-# PyTorch Nightly with CUDA 12.8 - For NVIDIA GPUs (including RTX 5070)
+# PyTorch 2.9.0 with CUDA 12.8 - For NVIDIA GPUs (including RTX 5070)
 # ==============================================================================
 #
-# WHY NIGHTLY:
-# - REQUIRED for RTX 5070 Blackwell architecture (sm_120 compute capability)
-# - Stable PyTorch 2.5.1 only supports up to sm_90 (Hopper/Ada)
-# - Nightly builds include latest GPU support and bug fixes
+# USING STABLE PYTORCH 2.9.0:
+# - PyTorch 2.7+ includes Blackwell architecture (sm_120) support
+# - CUDA 12.8 provides compatibility with RTX 50-series GPUs
+# - Stable release with production-ready features
 #
 # WHY CUDA 12.8:
 # - Latest stable CUDA version with broad GPU support
-# - More compatible than CUDA 13.0 which is still experimental
 # - Works with all NVIDIA drivers 535+
+# - Full Blackwell GPU support
 #
-# WHEN TO SWITCH TO STABLE:
-# - Once PyTorch 2.6+ stable is released with Blackwell support  
-# - Expected: Q1-Q2 2026
+# NOTE: 
+# - PyTorch 2.7 introduced prototype Blackwell support (April 2025)
+# - PyTorch 2.9 has more mature Blackwell support
 #
 # ==============================================================================
 
-# PyTorch nightly with CUDA 12.8
---extra-index-url https://download.pytorch.org/whl/nightly/cu128
+# PyTorch 2.9.0 stable with CUDA 12.8
+--index-url https://download.pytorch.org/whl/cu128
 
-torch --pre
-torchvision --pre
-torchaudio --pre
+torch==2.9.0
+torchvision==0.24.0
+torchaudio==2.9.0


### PR DESCRIPTION
Major cleanup and stabilization of the RTX 5070 Blackwell GPU support by switching from PyTorch nightly builds to stable PyTorch 2.9.0 and removing unnecessary workarounds.

## Changes Summary

### 1. PyTorch Version Upgrade
- **requirements-nvidia.txt**: Upgraded from nightly to PyTorch 2.9.0 stable with CUDA 12.8
- **requirements-cpu.txt**: Upgraded from nightly to PyTorch 2.9.0 stable CPU-only
- Both now use stable releases instead of experimental nightly builds

**Rationale**: PyTorch 2.7+ (released April 2025) introduced stable Blackwell architecture (sm_120) support for RTX 50-series GPUs. PyTorch 2.9.0 (October 2025) provides mature, production-ready support. Nightly builds are no longer necessary.

### 2. Removed LD_LIBRARY_PATH Configuration
- **install_packages_and_venv.sh**: Completely removed Step 10 (LD_LIBRARY_PATH setup)
  - Eliminated all .bashrc modification logic
  - Removed CUDNN library path configuration
  - Renumbered remaining steps (12 steps → 11 steps)
- **User system**: Cleaned up existing LD_LIBRARY_PATH entries from ~/.bashrc

**Rationale**: PyTorch 2.9.0 stable properly packages and locates CUDA libraries automatically. The LD_LIBRARY_PATH workaround was only needed for nightly builds that had packaging issues.

### 3. Documentation Updates
- **README.md**: Major updates throughout
  - Added "PyTorch Version History" section documenting evolution from nightly to stable
  - Rewrote "LD_LIBRARY_PATH Configuration" section to explain it's no longer needed
  - Added cleanup instructions for users upgrading from old setup
  - Updated all PyTorch version references from nightly to 2.9.0 stable
  - Clarified "What this script does" in Quick Setup section
  - Updated manual setup instructions to use stable PyTorch

### 4. Installation Script Improvements
- **install_packages_and_venv.sh**: Updated comments and descriptions
  - Step 4: Changed from "Installing PyTorch nightly" to "Installing PyTorch 2.9.0 stable"
  - Step 8: Added smart version checking - only reinstalls PyTorch if downgraded
  - Step 10 (old 11): Updated package verification step number
  - Step 11 (old 12): Updated environment setup step number
  - Final message: Changed reference from SETUP_RTX_5070.md to README.md

## Technical Details

### Dependency Chain (Unchanged)
The core dependency chain for RTX 5070 Blackwell support remains:
```
RTX 5070 (sm_120) → NVIDIA Driver 565+ → CUDA 12.8 → PyTorch 2.9.0 → pyannote 4.0.1+ → WhisperX
```

### Still Required (Legitimate Patches)
1. **WhisperX patches**: Still needed for HuggingFace API compatibility (use_auth_token → token)
2. **SpeechBrain patches**: Still needed for torchaudio 2.1+ compatibility

### Removed (No Longer Needed)
1. ✅ PyTorch nightly builds → Using stable 2.9.0
2. ✅ LD_LIBRARY_PATH configuration → Not needed with stable PyTorch
3. ✅ CUDA 13.0 consideration → Using stable CUDA 12.8

## Benefits

- **More stable**: Production-ready releases instead of experimental nightly builds
- **Cleaner installation**: 11 steps instead of 12, no .bashrc modifications
- **Better reliability**: Stable PyTorch handles library paths correctly
- **Easier maintenance**: Fewer moving parts and workarounds
- **Better portability**: Works across different system configurations
- **Full RTX 50-series support**: Mature Blackwell (sm_120) architecture support

## Testing Recommendations

After this update, users should:
1. Remove old venv: `rm -rf venv`
2. Reinstall: `./install_packages_and_venv.sh`
3. Clean .bashrc if upgrading: See README.md for instructions
4. Verify PyTorch version: `python3 -c "import torch; print(torch.__version__)"`
   - Expected: `2.9.0+cu128` (NVIDIA) or `2.9.0` (CPU)

## References

- PyTorch 2.7 (April 2025): First stable Blackwell support
- PyTorch 2.9.0 (October 2025): Mature Blackwell support
- CUDA 12.8: Latest stable CUDA with RTX 50-series support

Resolves issues with nightly build instability and simplifies the setup process while maintaining full RTX 5070 Blackwell GPU support.