### PR TITLE
Refresh quality assessments for opus/grok/gemini only

### DIFF
--- a/outputs/episode001/episode001_quality_assessment.md
+++ b/outputs/episode001/episode001_quality_assessment.md
@@ -1,165 +1,213 @@
-# Episode 001 (Kieren James-Lubin, Jim Hermosdiar, Victor Wong) -- Quality Assessment Report
+# Episode 001 -- Quality Assessment Report
 
 ## Overview
 
 - **Episode**: 001
-- **Speakers**: Kieren James-Lubin (host/SPEAKER_00), Jim/James Hermosdiar (SPEAKER_01), Victor Wong (SPEAKER_02)
+- **Speakers**: Kieren James-Lubin (host), Jim/James Hermosdiar, Victor Wong
 - **Topic**: Early days of Ethereum -- personal histories, founding drama, client development, crowd sale, ConsenSys, and launch
-- **Duration**: ~1h 52m
+- **Duration**: ~1h 56m (based on final timestamps)
 - **Transcriber bases**: 3 (whisperx, whisperx-cloud, assemblyai)
-- **AI processors**: 11 per transcriber base (opus, gemini, chatgpt, deepseek, glm, grok, kimi, minimax, llama, qwen, mistral)
-- **Total output files**: 33 processor outputs + 1 REVIEW_EXCERPTS.md
-- **Consensus pipeline**: Partial (assemblyai_consensus.md intermediate exists, no final.md)
+- **AI processors assessed**: 3 (opus, gemini, grok)
+- **Assessment date**: 2026-02-23
 
 ---
 
 ## 1. Transcriber Comparison
 
-| Attribute | whisperx (local) | whisperx-cloud | assemblyai |
+### Raw Transcript Word Counts
+
+| Transcriber | Word Count | Speaker Labels | Format |
 |---|---|---|---|
-| **Word count** | 18,886 | 18,840 | 19,043 |
-| **Speaker labels** | SPEAKER_00/01/03/04 (4 speakers, inconsistent) | SPEAKER_00/02/05 (3 speakers) | SPEAKER_00/01/02 (3 speakers, clean) |
-| **Diarization quality** | Moderate -- uses 5 speaker IDs (00,01,03,04, UNKNOWN); some speaker turns are misattributed; blends dialog from two speakers into one block occasionally | Good -- 3 speaker IDs properly map to the 3 participants; occasional mixed-case formatting (some blocks all-lowercase, some properly capitalized) | Best -- clean 3-speaker diarization; consistent formatting; proper sentence boundaries |
-| **Timestamp format** | [MM:SS] per turn | [MM:SS] per turn | [MM:SS] per turn (more granular turn splits) |
-| **Punctuation** | Mixed -- some blocks well-punctuated, some run-on lowercase | Mixed -- similar to whisperx but slightly better capitalization patterns | Best -- consistent capitalization and sentence boundaries |
-| **Name recognition** | "Karen James Lubin", "Hermosdiar" | "Karen James Lubin", "Hermosdiar" | "Kieran James Lubin", "from OzDR" |
-| **Key ASR errors** | "Karen" for Kieren; SPEAKER_03 appears for brief interjections; UNKNOWN speaker tag | "Karen" for Kieren; speaker 05 used for host (numbering differs) | "Kieran" for Kieren (closer); "from OzDR" heard for surname; "Monk Gox" for Mt. Gox |
-| **Corruption** | None detected | None detected | None detected |
+| **whisperx** (local) | 18,886 | SPEAKER_00 through SPEAKER_04 (5 labels) | `**[HH:MM] SPEAKER_XX:**` wall-of-text paragraphs |
+| **whisperx-cloud** | 18,840 | SPEAKER_00, SPEAKER_02, SPEAKER_05 (3 main + extras) | `**[HH:MM] SPEAKER_XX:**` wall-of-text paragraphs |
+| **assemblyai** | 19,043 | SPEAKER_00, SPEAKER_01, SPEAKER_02 (3 labels) | `**[HH:MM] SPEAKER_XX:**` sentence-level segments |
 
-**Assessment**: AssemblyAI provides the cleanest transcriber output with correct 3-speaker diarization, best punctuation, and most granular turn splits. WhisperX-cloud is second with correct speaker count but mixed formatting. WhisperX local has diarization issues (extra speaker IDs, UNKNOWN tags) making it the weakest base for this episode.
+### Transcriber Quality Assessment
 
----
+**WhisperX (Local)**
+- Text quality: Good. Clean English, minimal garbled text. Some lowercase passages and filler words preserved but readable.
+- Speaker diarization: **Poor**. Uses 5 speaker labels (SPEAKER_00 through SPEAKER_04) for what is a 3-person conversation. Speaker assignments shift mid-conversation, making it unreliable for consistent speaker identification.
+- Timestamps: Present but may be less accurate than cloud variants. Final timestamp around 1:51.
+- Corruption: None detected. No garbled text, no repeated characters, no empty content.
 
-## 2. AI Processor Comparison -- AssemblyAI Base
+**WhisperX-Cloud**
+- Text quality: Good. Very similar quality to local WhisperX, clean prose.
+- Speaker diarization: **Moderate**. Uses SPEAKER_00, SPEAKER_02, SPEAKER_05 as primary labels plus occasional SPEAKER_03, SPEAKER_04. Better than local WhisperX (closer to 3 speakers) but uses non-sequential numbering and has some speaker-assignment errors. Occasionally merges multiple speakers into one segment.
+- Timestamps: Present, final timestamp around 1:00:00+ range in the first 100 lines (compact), suggesting different timestamp behavior from local. Actually reaches ~1:51.
+- Corruption: None detected.
 
-Max word count in this group: **22,731** (glm). However, glm output is invalid (see below), making the effective max **18,802** (opus).
+**AssemblyAI**
+- Text quality: **Best of the three**. Cleaner sentence boundaries, better capitalization, more natural reading. Proper nouns like "Kieran" and "BlockApps" are better capitalized.
+- Speaker diarization: **Best**. Clean 3-speaker diarization (SPEAKER_00, SPEAKER_01, SPEAKER_02) matching the 3 actual speakers. Very few speaker misassignments. Short interjections are properly attributed.
+- Timestamps: More granular. Accurate per-utterance timestamps at the sentence level rather than paragraph level.
+- Corruption: None detected.
 
-| Processor | Words | % of Max (18,802) | Lines | Complete? | Tier | Notes |
-|---|---|---|---|---|---|---|
-| **opus** | 18,802 | 100% | 1,136 | Yes -- full transcript to closing | **Tier 1** | Excellent. Proper paragraph breaks per speaker turn. Clean formatting. Corrects names (Kieren, Boneh, Dwolla, Mt. Gox). Preserves all content. Sub-timestamps within speaker turns. Best overall quality. |
-| **gemini** | 16,009 | 85% | 412 | Yes -- reaches closing | **Tier 1** | Very good. Complete through ending. Slightly condensed (removes some filler). Good name corrections (ConsenSys, Fry's). Proper [MM:SS] format throughout. Fewer internal timestamps than opus. |
-| **grok** | 17,855 | 95% | 550 | Yes -- reaches closing | **Tier 1** | Near-complete. Very faithful to source. Good formatting. Preserves virtually all content. Slightly less name correction than opus (leaves "Kieren" uncorrected to "Kieren James-Lubin" hyphenated). Solid. |
-| **chatgpt** | 11,090 | 59% | 350 | Truncated ~1:41:07 | **Tier 3** | Heavy summarization/condensation. Compresses long monologues into summaries. Output cuts off mid-sentence at line 351. Missing final ~11 minutes. Speaker labels preserved but much content lost. |
-| **kimi** | 11,708 | 62% | 312 | Yes -- reaches closing markers | **Tier 2** | Moderately condensed but retains structure. Some filler removed. Preserves speaker turns. Name corrections partial (Vlad Zampir uncorrected). Complete to end but significantly shorter. |
-| **deepseek** | 6,304 | 34% | 174 | Truncated ~43:00 | **Tier 3** | Good quality for what exists -- clean formatting, good name corrections (Dan Boneh, Jeff Wilcke, Amir Chetrit, Cardano). But covers only first ~43 minutes of ~112 minutes. Missing majority of content. |
-| **minimax** | 5,899 | 31% | 160 | Truncated ~34:00 | **Tier 3** | Covers only first ~34 minutes. Formatting is clean where present. Spelling "Kieren" correctly. Retains "Stephen Nureyev" uncorrected. Incomplete. |
-| **qwen** | 5,806 | 31% | 162 | Truncated ~33:44+ | **Tier 3** | Similar truncation to minimax. Virtually identical to raw assemblyai input -- minimal processing evident. Retains "Stephen Nureyev", "Dan Benet" uncorrected, "Mount GOG" uncorrected. Little added value. |
-| **mistral** | 5,286 | 28% | 162 | Truncated ~30:37 | **Tier 3** | Truncated early. Very little processing -- essentially passes through the raw transcript with timestamps shifted (+20 min error: first timestamp reads [20:00] instead of [00:00]). Serious timestamp offset error. |
-| **glm** | 22,731 | N/A | 806 | INVALID | **Tier 4** | Output begins with ~200 lines of chain-of-thought reasoning/planning notes (analyzing the prompt, listing name corrections, etc.) before any transcript content. Then outputs an abbreviated transcript with "... (rest of the transcript remains the same)" placeholder. Unusable as a processed transcript. |
-| **llama** | 1,078 | 6% | 18 | INVALID | **Tier 4** | Only 18 lines total. Outputs the first block and last block with "... (rest of the transcript remains the same)" in between. Effectively no processing performed. Unusable. |
+### Transcriber Verdict
+
+AssemblyAI is the best raw transcriber for this episode, with the cleanest diarization and text quality. WhisperX-cloud is second. WhisperX local has the worst diarization.
 
 ---
 
-## 3. AI Processor Comparison -- WhisperX-Cloud Base
+## 2. AI Processor Comparison
 
-Max word count: **20,555** (glm, but invalid). Effective max: **18,470** (opus).
+### Word Counts and Completeness
 
-| Processor | Words | % of Max (18,470) | Complete? | Tier | Notes |
-|---|---|---|---|---|---|
-| **opus** | 18,470 | 100% | Yes | **Tier 1** | Excellent. Similar quality to assemblyai_opus. Corrects speaker name from "Karen" to "Kieren". Clean paragraph formatting. Full content. |
-| **gemini** | 18,306 | 99% | Yes | **Tier 1** | Very strong. Nearly full word count. Complete to end. Good quality processing. |
-| **grok** | 18,209 | 99% | Yes | **Tier 1** | Very faithful, near-complete. Clean formatting. |
-| **kimi** | 13,749 | 74% | Yes (condensed) | **Tier 2** | Complete but condensed. Retains structure. |
-| **chatgpt** | 12,402 | 67% | Truncated | **Tier 2** | Better than assemblyai_chatgpt but still condensed/truncated. |
-| **llama** | 8,000 | 43% | Truncated | **Tier 3** | Much better than assemblyai_llama (8,000 vs 1,078 words), but still incomplete. |
-| **deepseek** | 6,970 | 38% | Truncated | **Tier 3** | Similar to assemblyai base -- partial coverage. |
-| **qwen** | 6,204 | 34% | Truncated | **Tier 3** | Minimal processing, early truncation. |
-| **mistral** | 6,188 | 34% | Truncated | **Tier 3** | Early truncation, minimal processing. |
-| **minimax** | 3,475 | 19% | Truncated | **Tier 3** | Very short, early truncation. |
-| **glm** | 20,555 | N/A | INVALID | **Tier 4** | Same chain-of-thought dump issue as assemblyai_glm. |
+| Output File | Words | Lines | % of Max (18,802) | Quality Tier |
+|---|---|---|---|---|
+| **assemblyai_opus** | 18,802 | 1,136 | 100% (max) | Tier 1 |
+| **assemblyai_grok** | 17,855 | 550 | 95.0% | Tier 1 |
+| **assemblyai_gemini** | 16,009 | 412 | 85.1% | Tier 2 |
+| **whisperx-cloud_opus** | 18,470 | 980 | 98.2% | Tier 1 |
+| **whisperx-cloud_gemini** | 18,306 | 266 | 97.4% | Tier 1 |
+| **whisperx-cloud_grok** | 18,209 | 190 | 96.8% | Tier 1 |
+| **whisperx_opus** | 18,213 | 1,137 | 96.9% | Tier 1 |
+| **whisperx_gemini** | 18,450 | 298 | 98.1% | Tier 1 |
+| **whisperx_grok** | 18,304 | 268 | 97.4% | Tier 1 |
+
+### Processor-by-Processor Assessment
+
+#### Opus (Claude)
+
+**assemblyai_opus (18,802 words, 1,136 lines)**
+- Format: Speaker name headers on own line (e.g., `**SPEAKER_00:**`), followed by timestamped paragraphs `[HH:MM]`. Consistent formatting throughout.
+- Completeness: Full coverage from [00:00] to [116:14]. All content preserved.
+- Speaker labels: Retains original AssemblyAI labels (SPEAKER_00, SPEAKER_01, SPEAKER_02). Consistent and correct.
+- Prose quality: Excellent. Natural conversational flow preserved. Proper capitalization, punctuation, and formatting. Filler words cleaned up appropriately. Names properly rendered (Kieren James-Lubin, Rui Guo, Dan Boneh, etc.).
+- Technical accuracy: High. Blockchain terminology correct (testnet, EVM, Haskell client, Geth, etc.).
+- **Tier 1**: Complete output, excellent quality.
+
+**whisperx-cloud_opus (18,470 words, 980 lines)**
+- Format: Same header-based format as assemblyai_opus. Clean and consistent.
+- Completeness: Full coverage from [00:00] to end. Reaches the closing segment.
+- Speaker labels: Uses original whisperx-cloud labels (SPEAKER_05, SPEAKER_02, SPEAKER_00, SPEAKER_04). Multiple labels but consistent with source.
+- Prose quality: Excellent. Well-formatted, clear prose.
+- **Tier 1**: Complete, excellent quality.
+
+**whisperx_opus (18,213 words, 1,137 lines)**
+- Format: Same as above. Consistent formatting.
+- Completeness: Full coverage to end of episode.
+- Speaker labels: Uses original whisperx labels (SPEAKER_04, SPEAKER_01, SPEAKER_00, SPEAKER_03). Has the 5-speaker problem from the source transcriber but Opus faithfully preserves them.
+- Prose quality: Excellent.
+- **Tier 1**: Complete, excellent quality.
+
+#### Gemini
+
+**assemblyai_gemini (16,009 words, 412 lines)**
+- Format: Inline format `**[HH:MM] SPEAKER_XX:**` with dense paragraphs. Fewer line breaks. Notably more condensed than opus output.
+- Completeness: Covers full episode from [00:00] to [1:14:50]. However, at 85.1% of max word count, this is notably shorter -- indicating condensation/summarization rather than truncation. The timestamps compress the content (e.g., the initial monologue runs to [00:00] as one massive paragraph).
+- Speaker labels: Retains original AssemblyAI 3-speaker labels. Correct.
+- Prose quality: Good. Reads well. Some quotation marks added around dialogue. Clean text.
+- Technical accuracy: Good. Correct terminology throughout.
+- **Tier 2**: Complete but condensed (~85% of full output). Good quality but loses some conversational detail.
+
+**whisperx-cloud_gemini (18,306 words, 266 lines)**
+- Format: Very dense inline format. Extremely long paragraphs spanning many minutes of conversation. Only 266 lines for 18,306 words.
+- Completeness: Full coverage. 97.4% of max. Closes with "Tell you about the time we saw Vitalik throw his shirt at someone."
+- Speaker labels: Correct, uses source labels.
+- Prose quality: Good. Well-formatted text within the dense paragraph structure.
+- **Tier 1**: Complete, good quality. Dense formatting.
+
+**whisperx_gemini (18,450 words, 298 lines)**
+- Format: Dense inline format, similar to whisperx-cloud_gemini.
+- Completeness: Full coverage. 98.1% of max.
+- Prose quality: Good.
+- **Tier 1**: Complete, good quality.
+
+#### Grok
+
+**assemblyai_grok (17,855 words, 550 lines)**
+- Format: Inline format `**[HH:MM] SPEAKER_XX:**` with moderate paragraph lengths.
+- Completeness: 95% of max word count. Full coverage from [00:00] to [1:52:19]. All timestamps present through to the closing segment.
+- Speaker labels: Retains original AssemblyAI 3-speaker labels. Correct.
+- Prose quality: Good. Clean text, natural reading. Some minor differences from opus (e.g., slightly less polish on proper nouns in some passages).
+- **Tier 1**: Complete output, good quality.
+
+**whisperx-cloud_grok (18,209 words, 190 lines)**
+- Format: Very dense. Only 190 lines for 18,209 words. Massive paragraphs.
+- Completeness: 96.8% of max. Full coverage to end.
+- Speaker labels: Uses source labels. Correct.
+- Prose quality: Good. Readable.
+- **Tier 1**: Complete, good quality. Extremely dense formatting.
+
+**whisperx_grok (18,304 words, 268 lines)**
+- Format: Dense inline format.
+- Completeness: 97.4% of max. Full coverage.
+- Prose quality: Good.
+- **Tier 1**: Complete, good quality.
 
 ---
 
-## 4. AI Processor Comparison -- WhisperX (Local) Base
+## 3. Cross-Transcriber Comparison
 
-Max word count: **22,672** (glm, invalid). Effective max: **18,450** (gemini).
+### Word Count by Processor Across Transcriber Bases
 
-| Processor | Words | % of Max (18,450) | Complete? | Tier | Notes |
-|---|---|---|---|---|---|
-| **gemini** | 18,450 | 100% | Yes | **Tier 1** | Strong. Complete. Good processing. Handles the 4+ speaker IDs from whisperx well. |
-| **grok** | 18,304 | 99% | Yes | **Tier 1** | Near-complete, faithful. Clean formatting. |
-| **opus** | 18,213 | 99% | Yes | **Tier 1** | Excellent quality. Corrects "Karen" to "Kieren". Clean formatting with sub-timestamps. Handles whisperx's extra speaker IDs gracefully. |
-| **kimi** | 14,452 | 78% | Yes (condensed) | **Tier 2** | Complete but condensed. |
-| **llama** | 6,799 | 37% | Truncated | **Tier 3** | Partial coverage. |
-| **minimax** | 6,389 | 35% | Truncated | **Tier 3** | Partial coverage. |
-| **qwen** | 6,285 | 34% | Truncated | **Tier 3** | Minimal processing, truncated. |
-| **mistral** | 5,538 | 30% | Truncated | **Tier 3** | Truncated, minimal processing. |
-| **chatgpt** | 3,653 | 20% | Truncated | **Tier 3** | Worst chatgpt result across bases -- very heavily truncated. |
-| **deepseek** | 2,259 | 12% | Truncated | **Tier 3** | Worst deepseek result. Covers only first ~15 minutes. |
-| **glm** | 22,672 | N/A | INVALID | **Tier 4** | Chain-of-thought dump. Unusable. |
+| Processor | assemblyai | whisperx-cloud | whisperx | Spread |
+|---|---|---|---|---|
+| **opus** | 18,802 | 18,470 | 18,213 | 589 (3.1%) |
+| **gemini** | 16,009 | 18,306 | 18,450 | 2,441 (13.2%) |
+| **grok** | 17,855 | 18,209 | 18,304 | 449 (2.4%) |
 
----
+### Key Observations
 
-## 5. Consensus Pipeline Status
+1. **Opus** produces the most consistent output across transcriber bases, with only a 3.1% spread. The assemblyai base yields the longest output, likely because AssemblyAI's cleaner diarization gives Opus more distinct content to preserve.
 
-- **File exists**: `intermediates/episode001/episode001_assemblyai_consensus.md` (19,755 words) plus `episode001_assemblyai_consensus_words.json`
-- **No final output**: No `*_final.md` file found in either intermediates or outputs
-- **Assessment**: The consensus intermediate exists but the pipeline was not completed to produce a final merged output. The consensus intermediate is slightly larger than the raw assemblyai transcript (19,755 vs 19,043 words), suggesting some enrichment was performed.
+2. **Gemini** shows the largest variation. The assemblyai_gemini output is significantly condensed (16,009 words, 85% of max), while whisperx-cloud_gemini and whisperx_gemini are near-full (18,306 and 18,450). This suggests Gemini condensed the AssemblyAI input more aggressively, possibly because AssemblyAI's more granular sentence-level segmentation led Gemini to merge and compress more.
+
+3. **Grok** produces very consistent output across all three bases (2.4% spread), comparable to Opus in consistency.
+
+4. **Formatting density**: Opus outputs have the most lines (980-1,137), meaning shorter, more readable paragraphs. Gemini and Grok outputs are much denser (190-550 lines), meaning longer paragraphs that are harder to scan.
 
 ---
 
-## 6. Cross-Transcriber Comparison
+## 4. Formatting Quality Comparison
 
-### Best processor results by transcriber base:
-
-| Transcriber | Best Processor | Words | Quality |
+| Attribute | Opus | Gemini | Grok |
 |---|---|---|---|
-| assemblyai | opus | 18,802 | Excellent -- best name corrections, cleanest formatting, most detailed sub-timestamps |
-| whisperx-cloud | opus | 18,470 | Excellent -- corrects "Karen" to "Kieren", clean output |
-| whisperx | gemini | 18,450 | Very good -- handles messy 4-speaker diarization well |
+| Paragraph structure | Header-based, short paragraphs | Dense inline, long paragraphs | Inline, moderate to long paragraphs |
+| Readability | Excellent | Good | Good |
+| Line count (avg) | ~1,084 | ~325 | ~363 |
+| Speaker header style | Separate line | Inline with timestamp | Inline with timestamp |
+| Timestamp granularity | Per paragraph (~30s intervals) | Per paragraph (variable) | Per paragraph (variable) |
+| Proper noun handling | Excellent (Kieren, Boneh, Geth) | Good (Kieran, Boneh, Geth) | Good (Kieren/Kieren, Boneh, Geth) |
 
-### Key differences observed:
+---
 
-1. **AssemblyAI + Opus** is the overall best combination because:
-   - AssemblyAI provides the cleanest 3-speaker diarization to start
-   - Opus produces the most thorough name/term corrections (Dan Boneh, Dwolla, Mt. Gox, Rui Guo for VC name, Kieren James-Lubin, packed vs parked)
-   - Highest word retention across all combinations
-   - Best sub-timestamp granularity within speaker turns
+## 5. Quality Tier Summary
 
-2. **WhisperX-cloud + Opus/Gemini** are strong alternatives with nearly equivalent quality, though the whisperx-cloud base has mixed capitalization that requires more AI correction.
-
-3. **WhisperX local** is the weakest base due to 4+ speaker IDs and UNKNOWN tags. Processors handle this variably -- opus/gemini/grok compensate well, but weaker processors propagate the errors.
-
-### Processor consistency across bases:
-
-| Processor | Consistency | Assessment |
+| Tier | Description | Outputs |
 |---|---|---|
-| **opus** | Very consistent -- Tier 1 on all three bases | Top pick. Always complete, always high quality. |
-| **gemini** | Very consistent -- Tier 1 on all three bases | Second pick. Complete and well-formatted. Slightly more condensed than opus. |
-| **grok** | Very consistent -- Tier 1 on all three bases | Third pick. Very faithful to source. Slightly less name correction than opus. |
-| **kimi** | Consistent -- Tier 2 on all three bases | Usable but condensed (~62-78% retention). |
-| **chatgpt** | Inconsistent -- ranges from Tier 2 to Tier 3 depending on base | Unpredictable truncation. Worst on whisperx (3,653w), best on whisperx-cloud (12,402w). |
-| **deepseek** | Consistent -- Tier 3 on all bases | Always truncates partway through. Good quality where present. |
-| **minimax** | Consistent -- Tier 3 on all bases | Always truncates early. |
-| **qwen** | Consistent -- Tier 3 on all bases | Minimal processing, early truncation. |
-| **mistral** | Consistent -- Tier 3 on all bases | Minimal processing, timestamp errors on assemblyai base, early truncation. |
-| **llama** | Highly inconsistent | Unusable on assemblyai (1,078w), poor on others (6,799-8,000w). Never complete. |
-| **glm** | Consistent -- Tier 4 on all bases | Always outputs chain-of-thought reasoning instead of processed transcript. Completely broken. |
+| **Tier 1** | Complete (>90% of max), excellent/good quality | assemblyai_opus, assemblyai_grok, whisperx-cloud_opus, whisperx-cloud_gemini, whisperx-cloud_grok, whisperx_opus, whisperx_gemini, whisperx_grok |
+| **Tier 2** | Mostly complete or condensed, good quality | assemblyai_gemini |
+| **Tier 3** | Severely truncated (<50%) | None |
+| **Tier 4** | Unusable | None |
 
 ---
 
-## 7. Recommendations
+## 6. Recommendations
 
-### Best combination
-**AssemblyAI + Opus** -- produces the highest-quality, most complete, best-corrected transcript.
+### Best Transcriber + Processor Combinations
 
-### Runner-up combinations
-1. **AssemblyAI + Gemini** -- nearly as good, slightly more condensed
-2. **AssemblyAI + Grok** -- very faithful, minimal name corrections vs. opus
-3. **WhisperX-cloud + Opus** -- excellent quality, good fallback if assemblyai unavailable
+1. **Best overall: assemblyai_opus** (18,802 words, Tier 1)
+   - Best diarization from AssemblyAI (clean 3-speaker labels)
+   - Most complete output (100% of max)
+   - Best formatting (readable paragraph structure, speaker headers on own lines)
+   - Best proper noun handling
+   - Recommended as the primary transcript for this episode
 
-### Processors to avoid
-- **GLM**: Completely broken. Outputs chain-of-thought planning notes instead of transcript. Must be excluded from all future runs or the prompt engineering must be fixed.
-- **Llama**: Unusable on assemblyai base, severely truncated on others. Not suitable for long-form transcripts.
-- **Mistral**: Timestamp offset errors, minimal processing, severe truncation. Very low value.
-- **Qwen**: Minimal processing -- essentially passes through raw transcript unchanged with no corrections. Truncates early.
+2. **Runner-up: whisperx-cloud_opus** (18,470 words, Tier 1)
+   - Good diarization from whisperx-cloud
+   - Excellent formatting
+   - 98.2% completeness
+   - Good alternative if AssemblyAI base is unavailable
 
-### Pipeline recommendations
-1. Complete the consensus pipeline to produce a `*_final.md` from the existing consensus intermediate
-2. Consider dropping glm, llama, mistral, and qwen from the processor pipeline for this episode type (long-form multi-speaker conversation) as they consistently fail
-3. The chatgpt processor should be investigated for truncation behavior -- it performs variably across transcriber bases, suggesting possible context window or rate limit issues
-4. DeepSeek produces good quality where it runs but consistently truncates -- likely a context length limitation
+3. **Best Grok output: assemblyai_grok** (17,855 words, Tier 1)
+   - Clean diarization, 95% completeness
+   - Solid output with good technical accuracy
 
----
+### Notes
 
-*Report generated: 2026-02-22*
+- All nine outputs are usable (no Tier 3 or Tier 4 outputs)
+- The only output below 90% is assemblyai_gemini at 85.1%, which is still usable but condensed
+- For this episode, Opus consistently produces the best-formatted and most complete output across all transcriber bases
+- Grok is a reliable second choice with very consistent output across bases
+- Gemini is variable: excellent with whisperx/whisperx-cloud bases but over-condenses the assemblyai base

--- a/outputs/episode002/episode002_quality_assessment.md
+++ b/outputs/episode002/episode002_quality_assessment.md
@@ -1,137 +1,183 @@
-# Episode 002 (BlockApps Co-founders: Kieran, Victor, Jim) — Quality Assessment Report
+# Episode 002 Quality Assessment Report
 
-**Date:** 2026-02-22
-**Episode Duration:** ~1 hour 11 minutes
-**Topic:** Early days of Ethereum post-launch — ConsenSys Dappathons, Devcon 1, Microsoft partnership, The DAO hack, CoinDesk Consensus Hackathon, Devcon 2 in Shanghai, formation of the Enterprise Ethereum Alliance (EEA)
-
----
-
-## 1. Transcriber Comparison
-
-Three transcriber sources exist for this episode:
-
-| Transcriber | File | Lines | Speaker IDs | Diarization Quality | Timestamps | Notes |
-|---|---|---|---|---|---|---|
-| **WhisperX (local)** | `episode002_whisperx.md` | ~100 (large paragraphs) | SPEAKER_00, SPEAKER_01, SPEAKER_03, UNKNOWN | Fair — uses 4 speaker IDs; SPEAKER_03 = Kieran, SPEAKER_00 = Victor, SPEAKER_01 = Jim. Occasional UNKNOWN tag. Long monolithic paragraphs. | Per-paragraph | Paragraphs are very long (some 500+ words per entry). Diarization occasionally collapses multiple speakers into one paragraph. Some crosstalk artifacts. |
-| **WhisperX Cloud** | `episode002_whisperx-cloud.md` | ~100 (large paragraphs) | SPEAKER_00, SPEAKER_02, SPEAKER_04 | Fair — uses 3 speaker IDs; SPEAKER_04 = Kieran, SPEAKER_00 = Victor, SPEAKER_02 = Jim. Multiple speakers collapsed into single paragraphs (worse than local WhisperX). | Per-paragraph | Similar to local WhisperX but with more aggressive paragraph merging. Some segments combine 3+ speaker turns into one block. |
-| **AssemblyAI** | `episode002_assemblyai.md` | ~100 (structured) | SPEAKER_00, SPEAKER_01, SPEAKER_02 | Good — uses 3 speaker IDs consistently; SPEAKER_00 = Kieran, SPEAKER_01 = Victor, SPEAKER_02 = Jim. Much better turn-by-turn separation. | Per-turn | Best diarization of the three. Shorter, more accurate paragraphs per speaker turn. Clean separation between speakers. |
-
-**Consensus file:** `episode002_assemblyai_consensus.md` and `episode002_assemblyai_consensus_words.json` exist, suggesting the consensus pipeline was run using AssemblyAI as the base.
-
-**Transcriber Assessment Summary:**
-- **AssemblyAI** provides the best base for AI processing: proper 3-speaker diarization with good turn separation, clean timestamps, and consistent speaker labeling.
-- **WhisperX local** has reasonable diarization but uses 4 speaker IDs (including SPEAKER_03 and an UNKNOWN) and produces very long paragraphs that make speaker attribution harder.
-- **WhisperX Cloud** has similar issues to local WhisperX but with even more aggressive paragraph merging, sometimes combining multiple speakers into one block.
+**Date:** 2026-02-23
+**Episode:** episode002 (BlockApps Co-founders: Kieran James-Lubin, Victor Wong, Jim Hermosdia)
+**Episode Duration:** ~60 minutes (timestamps end around 59:40 in assemblyai_opus; whisperx_grok timestamps extend to ~1:11:13 due to timestamp drift)
+**Topic:** Early days of Ethereum post-launch: ConsenSys Dappathons, Devcon 1, Microsoft/Azure partnership, The DAO hack and hard fork, CoinDesk Consensus Hackathon, Devcon 2 in Shanghai, formation of the Enterprise Ethereum Alliance (EEA)
 
 ---
 
-## 2. AI Processor Comparison — AssemblyAI Base
+## 1. File Inventory
 
-The AssemblyAI transcriber base was processed by 11 different AI models. The largest complete output (GLM at ~856 lines total including a second pass) serves as the approximate reference for max coverage.
+### Intermediates (Raw Transcriber Outputs)
 
-| Processor | Lines | Est. Word Count | Completeness | Quality | Tier | Notes |
-|---|---|---|---|---|---|---|
-| **GLM** | 562 (but includes duplicated transcript starting at line 520) | ~11,500 | Ends at ~27 min then re-starts the full transcript. Effectively a failed run — duplicated output. | Fair formatting, clean timestamps, proper speaker labels. But the duplicate is a processing failure. | Tier 3 | Duplication artifact makes it unreliable. First pass covers only ~45% of the episode. |
-| **Opus** | 635 | ~11,800 | Complete — covers from 00:00 to 59:40 with proper closing. All major topics covered. | Excellent. Clean formatting, proper speaker labels, accurate timestamps, good prose fidelity to the original. Capitalization of proper nouns (BlockApps, ConsenSys, Ethereum, etc.) is excellent. | Tier 1 | Best overall. Full coverage, high fidelity. |
-| **ChatGPT** | 509 | ~10,200 | Complete — covers from 00:01 to 1:11:13 with proper closing. All major topics covered. | Excellent. Clean formatting with proper speaker labels and timestamps. Light editorial cleanup of disfluencies while preserving meaning. Good proper noun handling. Some timestamps use hour:minute:second format for later segments. | Tier 1 | Full coverage, very polished. Slightly more cleaned-up prose than Opus. |
-| **Gemini** | 323 | ~6,500 | Complete — covers from 00:00 to 1:11:13 with proper closing. | Good. Clean formatting, good editorial cleanup of disfluencies. Slightly more condensed than Opus/ChatGPT — some passages are tightened. Good speaker attribution. | Tier 2 | Complete coverage but moderately condensed (~55% of max word count). |
-| **Grok** | 329 | ~6,600 | Complete — covers from 00:01 to full episode with proper closing. | Good. Clean formatting, proper timestamps. Faithful to original. | Tier 2 | Complete coverage, good quality, moderate condensation. |
-| **Kimi** | 329 | ~6,600 | Complete — covers from 00:01 to full episode with proper closing. | Good. Similar quality to Grok and Gemini. Clean speaker labels, good timestamps. | Tier 2 | Complete coverage, good quality, moderate condensation. |
-| **DeepSeek** | 197 | ~4,000 | Partial — covers only to ~38:45 (approximately the DAO section). Cuts off before CoinDesk Consensus Hackathon, Devcon 2, Shanghai, EEA formation. | Good quality for what it covers. Clean formatting, proper speaker labels. | Tier 3 | Cuts off roughly halfway. Missing ~30 minutes of content. |
-| **Mistral** | 86 | ~1,700 | Minimal — covers only to ~6:56 (first few minutes). Cuts off during the Dappathon discussion. | Clean formatting for what exists, but extremely incomplete. | Tier 4 | Covers less than 10% of the episode. Unusable. |
-| **Qwen** | 100 | ~2,000 | Minimal — covers only to ~9:58. | Clean formatting but extremely incomplete. | Tier 4 | Covers less than 15% of the episode. Unusable. |
-| **MiniMax** | 81 | ~1,600 | Minimal — covers only a few minutes. | Incomplete. | Tier 4 | Unusable. |
-| **Llama** | 1050+ | ~15,000+ (inflated) | **Catastrophically corrupted.** First ~480 lines contain reasonable transcript up to the mid-episode, then degenerates into repetitive garbage: hundreds of lines of "was like the DAO was like the DAO was like the DAO" etc. | First portion is adequate; second half is complete nonsensical repetition (hallucination loop). | Tier 4 | **CORRUPTED.** Must be discarded entirely. Classic repetition loop failure. |
+| File | Words | Lines |
+|---|---|---|
+| `episode002_whisperx.md` | 11,860 | 154 |
+| `episode002_whisperx-cloud.md` | 11,805 | 120 |
+| `episode002_assemblyai.md` | 11,909 | 338 |
 
----
+### Processed Outputs
 
-## 3. AI Processor Comparison — WhisperX Cloud Base
+| File | Words | Lines |
+|---|---|---|
+| `episode002_assemblyai_opus.md` | 11,814 | 634 |
+| `episode002_assemblyai_gemini.md` | 11,248 | 322 |
+| `episode002_assemblyai_grok.md` | 11,016 | 328 |
+| `episode002_whisperx_opus.md` | 11,605 | 278 |
+| `episode002_whisperx_gemini.md` | 11,248 | 212 |
+| `episode002_whisperx_grok.md` | 11,584 | 156 |
+| `episode002_whisperx-cloud_opus.md` | 11,313 | 777 |
+| `episode002_whisperx-cloud_gemini.md` | 11,330 | 230 |
+| `episode002_whisperx-cloud_grok.md` | 11,419 | 120 |
 
-| Processor | Lines | Est. Word Count | Completeness | Quality | Tier | Notes |
-|---|---|---|---|---|---|---|
-| **Opus** | 461 | ~9,200 | Complete — full episode coverage. | Excellent. Clean formatting, proper speaker labels. | Tier 1 | Comparable to AssemblyAI Opus. |
-| **GLM** | 328 | ~6,500 | Likely complete. | Good quality. | Tier 2 | Moderate condensation. |
-| **ChatGPT** | 171 | ~3,400 | Partial coverage. | Good formatting for what exists. | Tier 3 | Significantly condensed or truncated. |
-| **Gemini** | 116 | ~2,300 | Partial coverage. | Appears condensed. | Tier 3 | Limited content. |
-| **Grok** | 61 | ~1,200 | Minimal. | Incomplete. | Tier 4 | Unusable. |
-| **Kimi** | 57 | ~1,100 | Minimal. | Incomplete. | Tier 4 | Unusable. |
-| **Mistral** | 44 | ~900 | Minimal. | Incomplete. | Tier 4 | Unusable. |
-| **MiniMax** | 42 | ~800 | Minimal. | Incomplete. | Tier 4 | Unusable. |
-| **DeepSeek** | 41 | ~800 | Minimal. | Incomplete. | Tier 4 | Unusable. |
-| **Llama** | 37 | ~700 | Minimal. | Incomplete. | Tier 4 | Unusable. |
-| **Qwen** | 36 | ~700 | Minimal. | Incomplete. | Tier 4 | Unusable. |
+Other files: `REVIEW_EXCERPTS.md`
 
 ---
 
-## 4. AI Processor Comparison — WhisperX Local Base
+## 2. Transcriber Quality Assessment
 
-| Processor | Lines | Est. Word Count | Completeness | Quality | Tier | Notes |
-|---|---|---|---|---|---|---|
-| **GLM** | 354 | ~7,000 | Likely complete or near-complete. | Good quality. | Tier 2 | Moderate condensation. |
-| **ChatGPT** | 182 | ~3,600 | Partial. | Good formatting. | Tier 3 | Truncated. |
-| **Opus** | 140 | ~2,800 | Partial — appears truncated. | Good quality for what exists. | Tier 3 | Surprisingly short for Opus; likely hit a processing limit. |
-| **Gemini** | 107 | ~2,100 | Partial. | Good quality. | Tier 3 | Truncated. |
-| **Grok** | 79 | ~1,600 | Minimal. | Incomplete. | Tier 4 | Unusable. |
-| **Kimi** | 77 | ~1,500 | Minimal. | Incomplete. | Tier 4 | Unusable. |
-| **DeepSeek** | 73 | ~1,500 | Minimal. | Incomplete. | Tier 4 | Unusable. |
-| **Qwen** | 71 | ~1,400 | Minimal. | Incomplete. | Tier 4 | Unusable. |
-| **Llama** | 50 | ~1,000 | Minimal. | Incomplete. | Tier 4 | Unusable. |
-| **Mistral** | 46 | ~900 | Minimal. | Incomplete. | Tier 4 | Unusable. |
-| **MiniMax** | 40 | ~800 | Minimal. | Incomplete. | Tier 4 | Unusable. |
+### 2a. WhisperX (Local) — `episode002_whisperx.md`
 
----
+- **Speaker IDs:** SPEAKER_00 (Victor), SPEAKER_01 (Jim), SPEAKER_03 (Kieran), UNKNOWN (rare)
+- **Diarization Quality:** Fair. Uses 4 speaker IDs. Generally correct speaker attribution. Occasional UNKNOWN tag appears (line 57: `[25:14] UNKNOWN: Okay.`). Speaker turns are well separated into individual paragraphs.
+- **Timestamp Format:** Per-paragraph timestamps, e.g., `**[00:00] SPEAKER_03:**`
+- **Paragraph Structure:** Long paragraphs, especially for extended monologues. Some paragraphs exceed 500 words. Reasonable turn-by-turn separation for short exchanges.
+- **Corruption/Artifacts:** None detected. Clean text throughout. Some OCR-like artifacts in the raw transcription (e.g., "Justin Delacruz, Ph.D.:" and "David Price-" appear as speaker names mid-paragraph around the Augur discussion, line 29). These are hallucinated speaker attributions from WhisperX, not actual speakers.
+- **Overall Grade:** B
 
-## 5. Consensus Pipeline Status
+### 2b. WhisperX Cloud — `episode002_whisperx-cloud.md`
 
-- **Consensus base file:** `intermediates/episode002/episode002_assemblyai_consensus.md` exists (built from AssemblyAI transcriber base)
-- **Word-level JSON:** `intermediates/episode002/episode002_assemblyai_consensus_words.json` exists
-- **Final output:** No `*_final.md` file found in `outputs/episode002/`
-- **Status:** Consensus pipeline was initiated but no final merged output was produced.
+- **Speaker IDs:** SPEAKER_00 (Victor), SPEAKER_02 (Jim), SPEAKER_04 (Kieran)
+- **Diarization Quality:** Fair. Uses 3 speaker IDs consistently. More aggressive paragraph merging than local WhisperX -- some paragraphs combine multiple speaker turns into a single block, losing turn boundaries. For example, lines 11-12 merge Victor and Kieran's exchange into one SPEAKER_00 block.
+- **Timestamp Format:** Per-paragraph timestamps, e.g., `**[00:00] SPEAKER_04:**`
+- **Paragraph Structure:** Fewer but longer paragraphs (120 lines vs 154 for local WhisperX). Multiple speaker turns merged into single blocks.
+- **Corruption/Artifacts:** Same "Justin Delacruz, Ph.D." and "David Price-" hallucinated speaker artifacts in the Augur discussion section (line 17). Otherwise clean.
+- **Overall Grade:** B-
 
----
+### 2c. AssemblyAI — `episode002_assemblyai.md`
 
-## 6. Cross-Transcriber Comparison
+- **Speaker IDs:** SPEAKER_00 (Kieran), SPEAKER_01 (Victor), SPEAKER_02 (Jim)
+- **Diarization Quality:** Good. Best of the three transcribers. Uses 3 speaker IDs consistently with accurate turn-by-turn separation. Short exchanges are properly split into individual speaker turns. Much more granular than either WhisperX variant.
+- **Timestamp Format:** Per-turn timestamps, e.g., `**[00:01] SPEAKER_00:**`
+- **Paragraph Structure:** 338 lines with well-separated turns. Individual speaker segments are shorter and more accurate. Short interjections properly captured as separate turns.
+- **Corruption/Artifacts:** None detected. No hallucinated speaker names. Clean throughout.
+- **Overall Grade:** A-
 
-The AssemblyAI base consistently produced the best AI processor outputs across all models. Key observations:
+### Transcriber Ranking
 
-| Aspect | AssemblyAI Base | WhisperX Cloud Base | WhisperX Local Base |
-|---|---|---|---|
-| **Best output word count** | ~11,800 (Opus) | ~9,200 (Opus) | ~7,000 (GLM) |
-| **Number of Tier 1 outputs** | 2 (Opus, ChatGPT) | 1 (Opus) | 0 |
-| **Number of Tier 2 outputs** | 3 (Gemini, Grok, Kimi) | 2 (GLM, maybe ChatGPT) | 1-2 (GLM, ChatGPT) |
-| **Processor success rate** | 5/11 usable | 2-3/11 usable | 2-3/11 usable |
-| **Catastrophic failures** | 1 (Llama) | 0 | 0 |
-
-The AssemblyAI base with its better diarization (proper turn separation) appears to give AI processors more structure to work with, resulting in longer and more faithful outputs. The WhisperX bases, with their longer monolithic paragraphs, seem to cause many processors to truncate early or produce minimal output.
+1. **AssemblyAI** (A-) -- Best diarization, cleanest output, most granular speaker turns
+2. **WhisperX Local** (B) -- Decent diarization but long paragraphs and hallucinated speaker artifacts
+3. **WhisperX Cloud** (B-) -- Aggressive paragraph merging loses speaker turn boundaries; same hallucination artifacts
 
 ---
 
-## 7. Recommendations
+## 3. AI Processor Quality Assessment
 
-### Best Combination
-**AssemblyAI + Opus** is the clear winner for this episode:
-- Full episode coverage (00:00 to 59:40 in Opus timestamps / 1:11:13 in real time)
-- Excellent proper noun capitalization (BlockApps, ConsenSys, Ethereum, Devcon, EEA, etc.)
-- Faithful to original speech while cleaning up obvious disfluencies
-- Proper 3-speaker attribution throughout
-- All major topics covered: Dappathons, Augur/ICOs, Devcon 1, Microsoft/Azure partnership, The DAO hack/hard fork, CoinDesk Consensus Hackathon, Devcon 2 Shanghai, EEA formation, Quorum
+**Max word count:** 11,814 (assemblyai_opus)
+**Tier thresholds:**
+- Tier 1: >90% of max (>10,633 words), complete, excellent quality
+- Tier 2: 70-90% of max, mostly complete or condensed, good quality
+- Tier 3: 50-70% of max, significantly truncated
+- Tier 4: <50% of max, unusable
 
-### Runner-up
-**AssemblyAI + ChatGPT** is a strong second choice with slightly more editorial polish and full coverage.
+### 3a. AssemblyAI Base
 
-### Also Usable
-- **AssemblyAI + Gemini** — Complete but ~55% word count (good for summaries/condensed versions)
-- **AssemblyAI + Grok** and **AssemblyAI + Kimi** — Complete, moderate condensation
-- **WhisperX-Cloud + Opus** — Complete, good quality
+| Processor | Words | % of Max | Lines | Tier | Notes |
+|---|---|---|---|---|---|
+| **Opus** | 11,814 | 100% | 634 | **Tier 1** | Complete transcript, excellent formatting. Speaker labels on separate lines from timestamps. Granular paragraph breaks (634 lines). All content preserved through to closing remarks at [59:40]. |
+| **Gemini** | 11,248 | 95.2% | 322 | **Tier 1** | Complete transcript. Slightly condensed formatting with speaker+timestamp on same line. Minor editorial cleanup (e.g., adds quotation marks around "And then what?", "day one dapps"). Proper name corrections (Hormuzdiar, Cale Teeter). Ends at [58:57]. |
+| **Grok** | 11,016 | 93.2% | 328 | **Tier 1** | Complete transcript. Similar formatting to raw AssemblyAI with speaker+timestamp on same line. Timestamps match the raw transcript closely. Ends at [59:40] with "Thank you." Slightly more condensed than Opus. |
 
-### Processors to Avoid
-- **Llama**: Catastrophic repetition loop failure on the AssemblyAI base; minimal output on other bases. Should not be trusted for this episode.
-- **MiniMax**: Consistently produced minimal output across all transcriber bases.
-- **Mistral**: Consistently truncated early across all bases.
-- **Qwen**: Consistently truncated early across all bases.
-- **DeepSeek**: Partial on AssemblyAI base (cuts off at ~39 min), minimal on other bases.
+### 3b. WhisperX (Local) Base
 
-### Pipeline Recommendations
-1. The consensus pipeline should be completed to produce a `*_final.md` file using the AssemblyAI + Opus output as the primary source.
-2. Future processing runs on WhisperX bases may need increased context windows or chunking strategies, as most processors fail to produce complete output from these longer-paragraph inputs.
-3. The Llama processor needs investigation — the repetition loop is a known failure mode that should be caught and retried or flagged automatically.
+| Processor | Words | % of Max | Lines | Tier | Notes |
+|---|---|---|---|---|---|
+| **Opus** | 11,605 | 98.2% | 278 | **Tier 1** | Complete transcript. Uses 4 speaker IDs from WhisperX (SPEAKER_00, SPEAKER_01, SPEAKER_03, UNKNOWN). Well-structured with separate speaker/timestamp lines. Ends at [59:14] with "Thank you." |
+| **Gemini** | 11,248 | 95.2% | 212 | **Tier 1** | Complete transcript. Preserves WhisperX speaker IDs. Some editorial cleanup. Ends at [55:35] "Thank you." Timestamps appear compressed relative to other outputs. |
+| **Grok** | 11,584 | 98.1% | 156 | **Tier 1** | Complete transcript, but very long paragraphs (only 156 lines). Preserves raw WhisperX wall-of-text formatting. Ends at [1:11:13] "Thank you." Timestamp drift evident (1:11 vs ~60 min actual). |
+
+### 3c. WhisperX Cloud Base
+
+| Processor | Words | % of Max | Lines | Tier | Notes |
+|---|---|---|---|---|---|
+| **Opus** | 11,313 | 95.8% | 777 | **Tier 1** | Complete transcript. Most granular formatting of all outputs (777 lines). Breaks long monologues into timestamped sub-paragraphs. Uses 4 speaker IDs (SPEAKER_00, SPEAKER_02, SPEAKER_04, and occasional reassignment). Ends at [65:48] "Thank you." |
+| **Gemini** | 11,330 | 95.9% | 230 | **Tier 1** | Complete transcript. Clean formatting with good speaker turn separation. Some editorial improvements (quotation marks, proper name formatting). Ends at [59:12] "Thank you." |
+| **Grok** | 11,419 | 96.7% | 120 | **Tier 1** | Complete transcript but extremely dense formatting (120 lines). Massive paragraphs with multiple speaker turns merged. Preserves raw WhisperX-cloud wall-of-text style. Ends at [1:11:13] "Thank you." |
+
+### Processor Summary
+
+All 9 processed outputs are **Tier 1** -- complete and of good-to-excellent quality. Word counts are tightly clustered between 11,016 and 11,814 (a range of only ~7%), indicating no truncation occurred in any output.
+
+**Key differences are in formatting quality:**
+
+| Rank | Output | Words | Lines | Formatting Quality |
+|---|---|---|---|---|
+| 1 | `assemblyai_opus` | 11,814 | 634 | Excellent: granular paragraphs, clean speaker labels, best readability |
+| 2 | `whisperx-cloud_opus` | 11,313 | 777 | Excellent: most granular sub-paragraph timestamping |
+| 3 | `assemblyai_gemini` | 11,248 | 322 | Very good: editorial polish, proper name corrections |
+| 4 | `assemblyai_grok` | 11,016 | 328 | Good: faithful to source, clean formatting |
+| 5 | `whisperx-cloud_gemini` | 11,330 | 230 | Good: clean with editorial improvements |
+| 6 | `whisperx_opus` | 11,605 | 278 | Good: complete but fewer paragraph breaks |
+| 7 | `whisperx_gemini` | 11,248 | 212 | Acceptable: compressed timestamps |
+| 8 | `whisperx_grok` | 11,584 | 156 | Acceptable: wall-of-text paragraphs, timestamp drift |
+| 9 | `whisperx-cloud_grok` | 11,419 | 120 | Acceptable: extremely dense, minimal paragraph breaks |
+
+---
+
+## 4. Transcriber Base Comparison
+
+### Side-by-Side Observations
+
+**Speaker Identification:**
+- AssemblyAI: SPEAKER_00=Kieran, SPEAKER_01=Victor, SPEAKER_02=Jim
+- WhisperX Local: SPEAKER_03=Kieran, SPEAKER_00=Victor, SPEAKER_01=Jim, UNKNOWN (rare)
+- WhisperX Cloud: SPEAKER_04=Kieran, SPEAKER_00=Victor, SPEAKER_02=Jim
+
+All three transcribers correctly identified 3 speakers. WhisperX Local occasionally introduces a 4th (UNKNOWN) label. Speaker mapping is consistent within each transcriber but uses different numbering.
+
+**Textual Accuracy (opening line comparison):**
+- AssemblyAI: "All right, well, welcome back, everybody. The first episode of the early days of Ethereum actually got quite good critical reception on LinkedIn and Twitter."
+- WhisperX Local: "all right well welcome back everybody um the first episode of the early days of the theory I'm actually got quite good critical reception on LinkedIn in Twitter"
+- WhisperX Cloud: "all right well welcome back everybody um the first episode of the early days of ethereum actually got quite good critical reception on linkedin in twitter"
+
+AssemblyAI has proper capitalization and punctuation. WhisperX Local has a misrecognition ("the theory I'm" instead of "Ethereum"). WhisperX Cloud has correct words but no capitalization.
+
+**Diarization Granularity:**
+- AssemblyAI separates short interjections (e.g., "20 or 30" gets its own speaker turn at [03:16])
+- WhisperX variants merge short exchanges into surrounding paragraphs
+- AssemblyAI line count is 338 vs 154 (WhisperX) and 120 (WhisperX Cloud), reflecting more granular turn detection
+
+**Hallucination Artifacts:**
+- Both WhisperX variants hallucinate speaker names ("Justin Delacruz, Ph.D." and "David Price-") during the Augur/prediction markets discussion where Kieran is reading from Wikipedia. These appear to be OCR-like artifacts from the model.
+- AssemblyAI has no such hallucinations.
+
+**Timestamp Accuracy:**
+- AssemblyAI and WhisperX Local timestamps are generally consistent with each other (within a few seconds).
+- WhisperX Cloud timestamps are also generally aligned. No major drift observed in raw transcripts.
+- However, WhisperX Grok processed outputs show significant timestamp drift (final timestamp 1:11:13 vs ~59:40 for assemblyai_opus), suggesting the raw WhisperX timestamps may have accumulated error that Grok preserved rather than corrected.
+
+---
+
+## 5. Recommendations
+
+1. **Best base transcriber:** AssemblyAI provides the cleanest, most granular diarization with no artifacts. It should be the preferred base for processing.
+
+2. **Best processed output:** `episode002_assemblyai_opus.md` combines the best transcriber base with the most readable processor formatting (634 lines, granular paragraphs, clean speaker labels).
+
+3. **Runner-up:** `episode002_assemblyai_gemini.md` offers good editorial polish (proper name corrections like "Hormuzdiar" and "Cale Teeter") that could be valuable for a final version.
+
+4. **Formatting concern:** The WhisperX Grok outputs (`whisperx_grok` and `whisperx-cloud_grok`) have extremely dense paragraphs (120-156 lines total) that significantly reduce readability. They are complete but not recommended for direct use.
+
+5. **No truncation issues:** All 9 outputs are complete (Tier 1). This episode processed cleanly across all pipelines.
+
+---
+
+## 6. Quality Tier Summary
+
+| Tier | Outputs | Count |
+|---|---|---|
+| **Tier 1** (Complete, >90%) | assemblyai_opus, assemblyai_gemini, assemblyai_grok, whisperx_opus, whisperx_gemini, whisperx_grok, whisperx-cloud_opus, whisperx-cloud_gemini, whisperx-cloud_grok | 9 |
+| **Tier 2** (Mostly complete) | -- | 0 |
+| **Tier 3** (Truncated) | -- | 0 |
+| **Tier 4** (Unusable) | -- | 0 |

--- a/outputs/episode003-bob-summerwill/episode003-bob-summerwill_quality_assessment.md
+++ b/outputs/episode003-bob-summerwill/episode003-bob-summerwill_quality_assessment.md
@@ -1,174 +1,243 @@
 # Episode 003 (Bob Summerwill) — Quality Assessment Report
 
-**Date:** 2026-02-22
+**Date:** 2026-02-23
+**Assessed by:** Claude Opus 4.6 (self-assessment)
 **Episode Duration:** ~1h 19m
 **Topic:** Ethereum early history, foundation dynamics, The DAO hack, Ethereum Classic emergence
-**Speakers:** 5 (SPEAKER_00 through SPEAKER_04 in transcriber outputs)
+**Speakers:** 4-5 (varies by transcriber: AssemblyAI uses SPEAKER_00-03, WhisperX variants use SPEAKER_00-04)
 
 ---
 
 ## 1. Transcriber Comparison
 
-| Transcriber | Word Count | Speaker Diarization | Timestamp Accuracy | Technical Term Handling | Notable Issues |
+| Transcriber | Word Count | Speaker Count | Diarization Quality | Timestamp Format | Notable Issues |
 |---|---|---|---|---|---|
-| **WhisperX (local)** | 12,333 | 5 speakers (00-04); mostly accurate but some misattributions between speakers | Timestamps present, generally accurate | "C5" for C#, "Etheria" for Ethereum, "mainland" for mainnet, "Pyre theorem" for PyEthereum | Some speaker merging; speaker IDs generally stable |
-| **WhisperX-Cloud** | 12,325 | 5 speakers (00-04); significant speaker misattribution — Bob's speech frequently assigned to SPEAKER_00 instead of separate speaker | Timestamps present, generally accurate | "mainlet" for mainnet, "Soulsea" for Solc, slightly cleaner prose than local | Worst diarization of the three; multiple speaker swaps throughout |
-| **AssemblyAI** | 12,988 | 4 speakers (00-03); cleaner separation, Bob consistently SPEAKER_01 | Timestamps present and accurate | "seaport" for C#, "mainlet" for mainnet, "PI Ethereum" for PyEthereum | Best diarization; clearest speaker boundaries; slightly more words captured |
+| **AssemblyAI** | 12,988 | 4 (00-03) | Excellent | `[HH:MM:SS]` per turn | Best diarization; Bob is consistently SPEAKER_01; clean speaker boundaries; short interjections ("Yeah", "Yep") correctly attributed |
+| **WhisperX (local)** | 12,333 | 5 (00-04 + UNKNOWN) | Acceptable | `[MM:SS]` per turn | Longer paragraph blocks merge multiple speaker turns; SPEAKER_04 appears to be Kieren; some cross-speaker merging |
+| **WhisperX-Cloud** | 12,325 | 5 (00-04) | Poor | `[MM:SS]` per turn | Significant diarization errors; Bob's speech frequently assigned to SPEAKER_00; speakers confused/merged throughout |
 
-**Transcriber Assessment Summary:**
-- **Best overall:** AssemblyAI — superior diarization with consistent speaker identification, most complete word capture (12,988 words), and cleanest speaker boundaries.
-- **WhisperX (local):** Acceptable diarization with 5 speaker IDs. Some cross-speaker merging. Comparable word count to cloud version.
-- **WhisperX-Cloud:** Worst diarization — Bob Summerwill's extended monologues are frequently misattributed to other speakers. This creates significant problems for downstream AI processing.
-- **No corruption detected** in any transcriber output. All three are coherent and complete.
+### Transcriber Assessment Summary
+
+- **Best overall:** AssemblyAI -- superior diarization with consistent 4-speaker identification, most complete word capture (12,988 words), and cleanest speaker boundaries. Short acknowledgments ("Yeah", "Yep", "Okay") are properly attributed to the correct speakers.
+- **WhisperX (local):** Acceptable diarization with 5 speaker IDs. Uses longer paragraph blocks that sometimes merge multiple speakers within a single turn. Speaker IDs are generally stable but less granular.
+- **WhisperX-Cloud:** Worst diarization -- Bob Summerwill's extended monologues are frequently misattributed to SPEAKER_00. Multiple speaker swaps throughout. This creates significant problems for downstream AI processing, though the content itself is complete.
+- **No corruption detected** in any transcriber output. All three are coherent and contain the full episode content.
 
 ---
 
 ## 2. AI Processor Comparison — AssemblyAI Base
 
-Max word count from this base: 16,650 (GLM). Reference source: 12,988 words.
+Reference source: 12,988 words (raw transcriber). Max processor output: 11,805 words (Grok).
 
-| Processor | Words | % of Max | Tier | Speaker Labels | Name Corrections | Technical Accuracy | Prose Quality | Key Issues |
+| Processor | Words | Lines | % of Max | Tier | Speaker Labels | Name Corrections | Technical Accuracy | Prose Quality |
 |---|---|---|---|---|---|---|---|---|
-| **Opus** | 11,554 | 69% | **Tier 1** | Correct, consistent | "Bob Summerwill", "Kieren", "Ming", "Brian Behlendorf", "Slock.it", "Christoph Jentzsch", "Lefteris Karapetsas", "DEV AG" | Excellent — "mainnet", "cpp-ethereum", "pyethereum", "Solidity", "DevCon 0" | Excellent — clean filler removal, natural flow, proper paragraphing | Best quality output; superb name and technical corrections |
-| **ChatGPT** | 11,136 | 67% | **Tier 1** | Correct, consistent | "Bob Summerwill", "Kieren", "Ming", "Brian Behlendorf", "Slock.it" | Excellent — proper technical terms throughout | Excellent — good formatting with quotes around titles, natural prose | Strong contender; slightly less thorough name corrections than Opus |
-| **Gemini** | 11,777 | 71% | **Tier 1** | Correct, consistent | "Bob Summerwill", "Kieren", "Ming" | Very good — most technical terms correct | Very good — clean and readable | Solid output; slightly more verbose |
-| **Grok** | 11,805 | 71% | **Tier 1** | Correct, consistent | "Bob Summerwill", "Kieren", "Ming", "Brian Behlendorf" | Very good | Very good — natural conversational flow preserved | Reliable output |
-| **Kimi** | 11,660 | 70% | **Tier 1** | Correct, consistent | "Bob Summerwill", "Kieren", "Ming" | Very good | Very good | Solid, comparable to Grok |
-| **GLM** | 16,650 | 100% | **Tier 4 (Unusable)** | N/A | N/A | N/A | N/A | **FAILED: Output is the model's internal chain-of-thought reasoning, not a transcript.** Contains lines like "Analyze the Request", "Step-by-Step Processing", correction notes. No usable transcript produced. |
-| **DeepSeek** | 6,721 | 40% | **Tier 2** | Correct | "Bob Summerwill", "Kieren", "Ming" | Good — "cpp-ethereum", "Solidity" | Good — readable but condensed | Significant content compression; some late sections truncated |
-| **Llama** | 6,188 | 37% | **Tier 3** | Mostly correct | "Bob Summerwell" (WRONG), "Karen" retained | Adequate — some ASR artifacts remain ("mainlet") | Adequate — retains more filler words, less polished | Failed to correct guest name; minimal cleanup |
-| **MiniMax** | 5,903 | 35% | **Tier 3** | Correct | "Bob Summerwill", "Karen" for "Kieren" | Adequate — "Bing" retained for "Ming" | Adequate — some paragraphing issues | "Bing" instead of "Ming"; "Karen" not corrected to "Kieren" |
-| **Mistral** | 5,316 | 32% | **Tier 3** | Correct | "Bob Summerwill", "Gavin Wood", "Vitalik Buterin" (expanded), "Charles Hoskinson", "Vlad Zamfir", "Ming Chan", "Hudson Jameson", "Laura Shin" | Good — expands abbreviated names to full forms | Good prose quality but heavily condensed | Best name expansion of any model, but severe truncation; only ~41% of content |
-| **Qwen** | 5,822 | 35% | **Tier 3** | Correct | "Bob Summerwill", "Kieren" | Adequate | Adequate — readable but truncated | Significant content loss |
+| **Opus** | 11,554 | 340 | 98% | **Tier 1** | Correct (00-03), consistent | Excellent: "Bob Summerwill", "Kieren", "Ming", "Brian Behlendorf", "Slock.it", "Christoph Jentzsch", "Lefteris", "DEV AG", "Stiftung" | Excellent: "mainnet", "cpp-ethereum", "PyEthereum", "Solidity", "DevCon 0", "AlethZero", "Web3 Umbrella" | Excellent: clean filler removal, natural conversational flow, proper paragraphing, profanity sanitized to "mess with" |
+| **Gemini** | 11,777 | 276 | 100% | **Tier 1** | Correct (00-03), consistent | Excellent: adds contextual annotations like [Gavin Wood], [Enterprise Ethereum Alliance]; uses *italics* for book titles (*The Cryptopians*); backtick formatting for code (`solc`, `eth`) | Excellent: proper technical terms; inline code formatting distinguishes code from prose | Very good: longer paragraphs, more literary formatting; adds quotation marks around direct speech; slightly more verbose but highly readable |
+| **Grok** | 11,805 | 290 | 100% | **Tier 1** | Correct (00-03), consistent | Very good: "Bob Summerwill", "Kieren", "Ming", "Brian Behlendorf", "Slock.it" | Very good: correct technical terms throughout | Very good: natural conversational flow preserved; retains more raw speech patterns than Opus; less filler word cleanup; profanity retained ("fuck with") |
+
+### AssemblyAI Base — Detailed Notes
+
+**Opus:** The most polished output. Removes filler words ("you know", "like", "sort of") more aggressively than the others, resulting in cleaner prose. Timestamps use `[H:MM:SS]` format. Profanity is sanitized (e.g., "mess with" instead of the original expletive). Speaker turns are properly separated with bold timestamp+speaker headers. The closing segment is fully intact through "Cheers, guys."
+
+**Gemini:** The most formally formatted output. Uses inline code formatting for technical terms (`solc`, `eth`, `cpp-ethereum`), italics for book titles (*The Cryptopians*), and bracketed contextual annotations for proper nouns (e.g., [Gavin Wood], [EDCON], [Enterprise Ethereum Alliance]). This adds useful context but is stylistically heavier. Uses shorter timestamps (`[MM:SS]` format). Fewer lines (276 vs 340 for Opus) suggests longer paragraph blocks. The closing is complete through "Cheers, guys."
+
+**Grok:** The most faithful-to-source output. Retains more of the original speech patterns including filler words and profanity. Word count is highest (11,805) suggesting less aggressive cleanup. Timestamps use `[H:MM:SS]` format. Clean speaker attribution. The closing is fully intact. A solid, reliable middle-ground between raw and polished.
 
 ---
 
 ## 3. AI Processor Comparison — WhisperX (local) Base
 
-Max word count from this base: 24,665 (GLM). Excluding GLM anomaly, max is 12,231 (Gemini). Reference source: 12,333 words.
+Reference source: 12,333 words (raw transcriber). Max processor output: 12,231 words (Gemini).
 
-| Processor | Words | % of Max (excl. GLM) | Tier | Key Observations |
-|---|---|---|---|---|
-| **Opus** | 11,411 | 93% | **Tier 1** | Excellent quality; strong name/technical corrections; properly handles the 5-speaker diarization |
-| **ChatGPT** | 10,814 | 88% | **Tier 1** | Very good quality; slightly less complete than Opus |
-| **Gemini** | 12,231 | 100% | **Tier 1** | Most complete; good quality; slightly more verbose |
-| **Grok** | 11,433 | 93% | **Tier 1** | Very good quality; reliable |
-| **Kimi** | 12,148 | 99% | **Tier 1** | Very complete and good quality |
-| **GLM** | 24,665 | N/A | **Tier 4 (Unusable)** | **FAILED: Entire transcript duplicated (copy-pasted twice).** Content appears twice consecutively. The 24,665 word count is ~2x the expected ~12,000. |
-| **DeepSeek** | 6,477 | 53% | **Tier 2** | Condensed but readable; similar pattern to AssemblyAI base |
-| **Llama** | 6,190 | 51% | **Tier 3** | Retains ASR artifacts; "Bob Summerwell" not corrected |
-| **MiniMax** | 5,949 | 49% | **Tier 3** | Truncated; "Bing" for "Ming" retained |
-| **Mistral** | 5,988 | 49% | **Tier 3** | Heavily condensed; good name expansion but too much content lost |
-| **Qwen** | 6,080 | 50% | **Tier 3** | Truncated; adequate quality in retained content |
+| Processor | Words | Lines | % of Max | Tier | Speaker Labels | Key Observations |
+|---|---|---|---|---|---|---|
+| **Opus** | 11,411 | 158 | 93% | **Tier 1** | Uses 00-04 from source; maps Bob to SPEAKER_02, Kieren to SPEAKER_04 | Excellent quality; properly handles the 5-speaker WhisperX diarization; clean name and technical corrections; fewest lines (158) means longer consolidated paragraphs |
+| **Gemini** | 12,231 | 136 | 100% | **Tier 1** | Uses 00-04 from source | Most complete word count; retains more filler words ("you know", "sort of"); heaviest paragraphs (136 lines for 12K+ words); good technical formatting |
+| **Grok** | 11,433 | 146 | 94% | **Tier 1** | Uses 00-04 from source | Reliable output; retains more raw speech patterns; profanity retained; complete through closing; similar consolidation to Gemini |
+
+### WhisperX (local) Base — Detailed Notes
+
+All three processors produce complete, high-quality outputs from the WhisperX local base. The key difference from the AssemblyAI-based outputs is the speaker labeling: WhisperX uses 5 speakers (SPEAKER_00-04) whereas AssemblyAI uses 4 (SPEAKER_00-03). In the WhisperX base, Bob is SPEAKER_02 (vs SPEAKER_01 in AssemblyAI), and Kieren appears as SPEAKER_04.
+
+The outputs have notably fewer lines than their AssemblyAI counterparts (136-158 vs 276-340), suggesting the processors are consolidating the already-longer WhisperX paragraphs into even more extended blocks. All three outputs complete through the closing remarks. The WhisperX source mentions "Augur" where AssemblyAI has "DAI" as a contemporary project -- this is a transcriber-level difference that propagates through to all processor outputs.
 
 ---
 
 ## 4. AI Processor Comparison — WhisperX-Cloud Base
 
-Max word count from this base: 12,106 (Gemini). Excluding GLM. Reference source: 12,325 words.
+Reference source: 12,325 words (raw transcriber). Max processor output: 12,106 words (Gemini).
 
-| Processor | Words | % of Max | Tier | Key Observations |
-|---|---|---|---|---|
-| **Opus** | 11,583 | 96% | **Tier 1** | Excellent quality; compensates well for the poor diarization of the source |
-| **ChatGPT** | 10,630 | 88% | **Tier 1** | Very good quality |
-| **Gemini** | 12,106 | 100% | **Tier 1** | Most complete; good quality |
-| **Grok** | 11,988 | 99% | **Tier 1** | Very good quality and completeness |
-| **Kimi** | 12,062 | 100% | **Tier 1** | Very good; near-complete |
-| **GLM** | 807 | 7% | **Tier 4 (Unusable)** | **FAILED: Severely truncated.** Only ~807 words produced; output cuts off mid-sentence at the beginning of the episode. |
-| **DeepSeek** | 6,641 | 55% | **Tier 2** | Condensed but readable |
-| **Llama** | 6,857 | 57% | **Tier 2** | Slightly better than with other bases; still retains some artifacts |
-| **MiniMax** | 5,656 | 47% | **Tier 3** | Truncated |
-| **Mistral** | 6,089 | 50% | **Tier 3** | Heavily condensed; good name corrections |
-| **Qwen** | 6,132 | 51% | **Tier 3** | Truncated |
+| Processor | Words | Lines | % of Max | Tier | Speaker Labels | Key Observations |
+|---|---|---|---|---|---|---|
+| **Opus** | 11,583 | 526 | 96% | **Tier 1** | Uses 00-04 from source; maps Bob to SPEAKER_00 (inherits source diarization error) | Highest line count (526) -- significantly more granular speaker turns than other Opus outputs; compensates for poor diarization by creating frequent speaker breaks; uses `f***` censoring for profanity |
+| **Gemini** | 12,106 | 88 | 100% | **Tier 1** | Uses 00-04 from source | Most complete; fewest lines (88) means extremely long paragraphs; some speaker turns run thousands of words; inherits the diarization problems from the source |
+| **Grok** | 11,988 | 80 | 99% | **Tier 1** | Uses 00-04 from source | Fewest lines of all 9 outputs (80); massive paragraph blocks; inherits diarization problems; complete content but very hard to follow speaker changes |
 
----
+### WhisperX-Cloud Base — Detailed Notes
 
-## 5. Consensus Pipeline Status
+The whisperx-cloud base presents the most challenge for processors due to its poor speaker diarization. This manifests differently in each processor's output:
 
-**No `_final.md` file exists.** The consensus pipeline has not been run for this episode.
+**Opus (526 lines):** Attempts to compensate for the diarization issues by creating very frequent speaker turn breaks. This results in the highest line count of any output (526 vs 340 for assemblyai_opus). The output is structurally very different from the other Opus outputs -- each speaker turn is shorter and more granular. Despite this structural difference, the content quality remains excellent. Profanity is censored as `f***`.
+
+**Gemini (88 lines):** Takes the opposite approach -- consolidates into extremely long blocks. With only 88 lines for 12,106 words, individual paragraphs can run extremely long. The poor source diarization means speaker attribution within these blocks is unreliable. Content is complete but readability suffers from the wall-of-text formatting. Uses inline code formatting and contextual annotations as in the AssemblyAI-based output.
+
+**Grok (80 lines):** Even fewer lines than Gemini (80), creating the most consolidated output of all 9 files. Multiple speakers' dialogue is merged into single blocks. Like Gemini, the content is complete but speaker attribution is very difficult to follow. This is the least readable output of the 9 despite containing nearly complete content.
 
 ---
 
-## 6. Cross-Transcriber Comparison
+## 5. Cross-Transcriber Comparison
 
-Comparing outputs from the same AI processor across different transcriber bases reveals:
+### Side-by-Side: Same Processor, Different Bases
 
-### Opus (Best Processor)
+#### Opus Comparison
 | Metric | AssemblyAI + Opus | WhisperX + Opus | WhisperX-Cloud + Opus |
 |---|---|---|---|
 | Word Count | 11,554 | 11,411 | 11,583 |
+| Line Count | 340 | 158 | 526 |
 | Speaker IDs | 4 (00-03) | 5 (00-04) | 5 (00-04) |
-| Name "Kieren" | Correct | Correct | Correct |
-| Name "Ming" | Correct | Correct | Correct |
-| "DEV AG" / "Stiftung" | DEV AG | DEV AG | DEV AG |
-| "Slock.it" | Correct | Correct | Correct |
-| Overall Quality | Excellent | Excellent | Excellent |
+| Bob's Speaker ID | SPEAKER_01 | SPEAKER_02 | SPEAKER_00 |
+| Profanity Handling | Sanitized ("mess with") | Sanitized | Censored ("f***") |
+| Closing Line | "Cheers, guys." | "Cheers, guys." | "Cheers, guys." |
+| Readability | Excellent | Very good | Good (too many short turns) |
 
-**Key finding:** Opus produces consistently excellent results regardless of the transcriber base. The AssemblyAI base provides the cleanest speaker attribution, while Opus compensates well for diarization issues in the WhisperX variants.
-
-### GLM (Worst Processor)
-| Metric | AssemblyAI + GLM | WhisperX + GLM | WhisperX-Cloud + GLM |
+#### Gemini Comparison
+| Metric | AssemblyAI + Gemini | WhisperX + Gemini | WhisperX-Cloud + Gemini |
 |---|---|---|---|
-| Word Count | 16,650 | 24,665 | 807 |
-| Failure Mode | Chain-of-thought dump | Entire transcript doubled | Severely truncated |
-| Usable | No | No | No |
+| Word Count | 11,777 | 12,231 | 12,106 |
+| Line Count | 276 | 136 | 88 |
+| Code Formatting | Yes (`solc`, `eth`) | Yes | Yes |
+| Contextual Annotations | Yes ([Gavin Wood]) | Yes | Yes |
+| Closing Line | "Cheers, guys." | "Cheers, guys." | Complete |
+| Readability | Very good | Good (long paragraphs) | Poor (wall of text) |
 
-**Key finding:** GLM fails catastrophically across all three transcriber bases, each time in a different manner. This model is fundamentally unreliable for this task.
+#### Grok Comparison
+| Metric | AssemblyAI + Grok | WhisperX + Grok | WhisperX-Cloud + Grok |
+|---|---|---|---|
+| Word Count | 11,805 | 11,433 | 11,988 |
+| Line Count | 290 | 146 | 80 |
+| Profanity Handling | Retained | Retained | Retained |
+| Speech Patterns | More raw | More raw | Most raw (merged speakers) |
+| Closing Line | "Cheers guys." | Complete | Complete |
+| Readability | Good | Good | Poor (wall of text) |
+
+### Key Findings
+
+1. **All 9 outputs are complete (Tier 1).** No truncation detected in any output. All reach the closing segment with "Cheers, guys" or equivalent.
+
+2. **Word counts are remarkably consistent** across all 9 outputs (11,411 to 12,231), with variation under 7%. This indicates all three processors handle all three transcriber bases reliably.
+
+3. **Line count variation is dramatic** and reveals how processors handle different source structures:
+   - AssemblyAI base: 276-340 lines (moderate)
+   - WhisperX base: 136-158 lines (consolidated)
+   - WhisperX-Cloud base: 80-526 lines (wildly variable -- Opus fragments, Gemini/Grok consolidate)
+
+4. **Speaker attribution quality** directly depends on the transcriber base. No processor can fix the underlying diarization problems from whisperx-cloud.
+
+5. **The "Augur" vs "DAI" discrepancy:** WhisperX transcribes a project mention as "Augur" (and Grok retains this), while AssemblyAI transcribes it as "DAI." Gemini on the AssemblyAI base writes "DAI" while the WhisperX outputs use "Augur" or "DAI" depending on the processor. This is a genuine content ambiguity from the audio.
 
 ---
 
-## 7. Detailed Quality Notes
+## 6. Processor Quality Rankings
 
-### Specific Name/Term Corrections Observed
+### Tier 1 Outputs (All 9)
 
-| Original ASR | Correct Form | Fixed By (Models) |
-|---|---|---|
-| "Bob Summerwell" | Bob Summerwill | Opus, ChatGPT, Gemini, Grok, Kimi, Mistral, MiniMax, Qwen, DeepSeek |
-| "Bob Summerwell" | Bob Summerwill | NOT fixed by: Llama |
-| "Karen" / "Kieran" | Kieren | Opus, ChatGPT, Gemini, Grok, DeepSeek |
-| "Karen" | Kieren | NOT fixed by: Kimi (inconsistent), MiniMax, Llama, Mistral |
-| "Bing" (Ming Chan) | Ming | Opus, ChatGPT, Grok, DeepSeek, Mistral |
-| "Bing" | Ming | NOT fixed by: MiniMax, Llama, Qwen |
-| "mainlet" / "mainland" | mainnet | All Tier 1 processors |
-| "seaport" / "C5" | C# / C++ | Opus, ChatGPT (C#); others vary |
-| "Slocket" / "Slockit" | Slock.it | Opus, ChatGPT, DeepSeek |
-| "Brian Bellendorf" | Brian Behlendorf | Opus, ChatGPT, Grok, Mistral |
-| "Christoph Jentz" | Christoph Jentzsch | Opus, DeepSeek |
-| "Anthony Diorio" | Anthony Di Iorio | All processors on AssemblyAI base |
-| "Pyre theorem" | PyEthereum | All Tier 1 processors |
+All nine processor outputs qualify as Tier 1 (complete, readable, high quality). However, there are meaningful quality differences:
 
-### Speaker Diarization Handling
+**Rank 1: assemblyai_opus** -- Best overall combination.
+- Cleanest speaker diarization (4 speakers, correct attribution)
+- Best name corrections (Christoph Jentzsch, Lefteris, Brian Behlendorf, DEV AG, Stiftung)
+- Most polished prose with appropriate filler removal
+- Professional formatting with reasonable paragraph lengths (340 lines)
 
-The whisperx-cloud base has the worst diarization, with Bob Summerwill's extended monologues frequently merged with other speakers. Remarkably, the Tier 1 AI processors (Opus, ChatGPT, Gemini, Grok, Kimi) appear to handle this reasonably well, likely because the conversational content itself provides contextual cues for speaker identification. However, for maximum accuracy, the AssemblyAI base is preferred.
+**Rank 2: assemblyai_gemini** -- Best formatted, most complete.
+- Inline code formatting and contextual annotations add scholarly value
+- Highest word count from AssemblyAI base (11,777)
+- Italic formatting for book titles, proper quotation handling
+- Slightly more verbose but highly readable (276 lines)
+
+**Rank 3: assemblyai_grok** -- Most faithful, highest word count.
+- Retains the most content from the source (11,805 words)
+- Preserves conversational authenticity including profanity
+- Less aggressive cleanup means closer to the original speech
+- Good formatting (290 lines)
+
+**Rank 4: whisperx_opus** -- Best WhisperX output.
+- Excellent quality despite 5-speaker complexity
+- Clean and polished (158 lines, very consolidated)
+- Proper name and technical corrections
+
+**Rank 5: whisperx_gemini** -- Most complete overall.
+- Highest word count of all 9 outputs (12,231)
+- Good formatting consistency
+- 136 lines means long but readable paragraphs
+
+**Rank 6: whisperx_grok** -- Reliable WhisperX output.
+- Complete and faithful (11,433 words, 146 lines)
+- Retains speech patterns well
+
+**Rank 7: whisperx-cloud_opus** -- Structurally unusual but content-complete.
+- 526 lines is an outlier; very fragmented speaker turns
+- Content quality is still excellent
+- The extreme fragmentation makes it harder to read as a flowing transcript
+
+**Rank 8: whisperx-cloud_gemini** -- Complete but hard to read.
+- 88 lines for 12K+ words creates wall-of-text blocks
+- Speaker attribution unreliable due to source diarization
+- Content is all there but readability suffers
+
+**Rank 9: whisperx-cloud_grok** -- Least readable.
+- Only 80 lines for nearly 12K words
+- Massive paragraph blocks with merged speakers
+- Complete content but worst readability of all 9
+
+---
+
+## 7. Specific Name/Term Corrections Observed
+
+| Original ASR | Correct Form | Opus | Gemini | Grok |
+|---|---|---|---|---|
+| "Bob Summerwell" | Bob Summerwill | Yes | Yes | Yes |
+| "Karen" / "Kieran" | Kieren | Yes | Yes | Yes |
+| "Bing" / "Ming" | Ming | Yes | Yes | Yes |
+| "Brian Bellendorf" | Brian Behlendorf | Yes | Yes | Yes |
+| "mainlet" / "mainland" | mainnet | Yes | Yes | Yes |
+| "Christoph Jentz" | Christoph Jentzsch | Yes | Partially | Partially |
+| "Slocket" / "Slockit" | Slock.it | Yes | Yes | Yes |
+| "C5" / "seaport" | C++ / C# | Yes | Yes | Yes |
+| "Pyre theorem" / "PI Ethereum" | PyEthereum | Yes | Yes | Yes |
+| "DEV AG" (from "EthDev") | EthDev AG / DEV AG | Yes | Yes | Yes |
+| "Stiftung" | Stiftung (correct, retained) | Yes | Yes | Yes |
+| Profanity handling | -- | Sanitized | Context-dependent | Retained |
+
+All three processors handle core name and technical corrections well. Opus is the most thorough, particularly on less common names (Christoph Jentzsch, Lefteris Karapetsas). Gemini adds the most formatting polish. Grok is the most faithful to the original speech.
 
 ---
 
 ## 8. Recommendations
 
 ### Best Combination
-**AssemblyAI + Opus** — This combination offers:
+**AssemblyAI + Opus** -- This combination offers:
 - Best source diarization (4 consistent speakers, clean boundaries)
-- Most accurate name corrections (Kieren, Ming, Slock.it, Christoph Jentzsch, Lefteris Karapetsas, Brian Behlendorf, DEV AG)
-- Excellent technical term handling (mainnet, cpp-ethereum, pyethereum, Solidity, DevCon)
+- Most accurate and thorough name corrections
+- Excellent technical term handling
 - Clean prose with appropriate filler removal while preserving conversational tone
-- Complete coverage (~89% of raw word count, reflecting proper cleanup)
+- Complete coverage with professional formatting (340 lines, ~11,554 words)
 
 ### Runner-Up Combinations
-1. **AssemblyAI + ChatGPT** — Nearly as good as Opus; slightly less thorough on name corrections
-2. **AssemblyAI + Gemini** — Most complete word count; solid quality
-3. **AssemblyAI + Grok** — Reliable and consistent
-
-### Processors to Avoid
-1. **GLM** — Fails catastrophically on all three bases (chain-of-thought dump, duplication, severe truncation). Must not be used.
-2. **Llama** — Fails to correct the guest's name ("Bob Summerwell"), retains ASR artifacts, minimal value-add over raw transcript.
-3. **MiniMax** — "Bing" for "Ming", "Karen" for "Kieren"; heavy truncation loses significant content.
+1. **AssemblyAI + Gemini** -- Most formally formatted; best for scholarly or reference use; adds useful contextual annotations
+2. **AssemblyAI + Grok** -- Most faithful to original speech; best for preserving conversational authenticity
+3. **WhisperX + Opus** -- Best non-AssemblyAI option; good for consensus pipeline diversity
 
 ### Transcriber Recommendation
-- **Primary:** AssemblyAI (best diarization, most words captured)
-- **Secondary:** WhisperX (local) (acceptable diarization, good word capture)
-- **Avoid as primary:** WhisperX-Cloud (poor diarization quality for this episode)
+- **Primary:** AssemblyAI (best diarization, most words captured, cleanest speaker boundaries)
+- **Secondary:** WhisperX (local) (acceptable diarization, good word capture, useful for cross-reference)
+- **Tertiary:** WhisperX-Cloud (complete content but poor diarization; use only for consensus diversity)
 
-### Next Steps
-1. Run the consensus pipeline using the top 3-4 AssemblyAI-based outputs (Opus, ChatGPT, Gemini, Grok) to produce a `_final.md`
-2. Consider re-processing with GLM excluded from any future pipeline runs
-3. The Mistral processor shows promise for name expansion (full names with context) but needs to be configured to avoid severe content truncation
+### Consensus Pipeline Notes
+All 9 outputs are Tier 1, making this episode an excellent candidate for a consensus pipeline run. The top candidates for consensus input would be the three AssemblyAI-based outputs plus whisperx_opus for diversity.
+
+### Key Quality Observations
+1. This is a high-quality episode for transcription -- Bob Summerwill speaks clearly and at a measured pace, resulting in excellent ASR quality across all transcribers.
+2. The episode covers highly specific Ethereum history with many proper nouns, making AI processor name correction capability particularly important.
+3. All three processors (Opus, Gemini, Grok) perform at Tier 1 across all three bases -- no failures, no truncation, no hallucination detected.
+4. The main quality differentiator between outputs is readability/formatting rather than content completeness.

--- a/outputs/episode004-taylor-gerring/episode004-taylor-gerring_quality_assessment.md
+++ b/outputs/episode004-taylor-gerring/episode004-taylor-gerring_quality_assessment.md
@@ -4,169 +4,243 @@
 
 - **Episode**: Episode 004 -- Taylor Gerring (early Ethereum history, Twitter Spaces conversation)
 - **Duration**: Approximately 1 hour 11 minutes
-- **Speakers**: 5 speakers (Taylor Gerring, Bob Summerwill, Kieren James-Lubin, plus host/moderator and one minor speaker)
-- **Transcriber bases**: 3 (WhisperX local, WhisperX Cloud, AssemblyAI)
-- **AI processors**: 11 (Opus, Gemini, ChatGPT, Grok, Kimi, GLM, DeepSeek, Mistral, Qwen, Llama, MiniMax)
-- **Total output files**: 33 processor outputs + 1 REVIEW_EXCERPTS.md
-- **Consensus final**: Not generated
+- **Speakers**: 5 speakers (Taylor Gerring as primary guest, Bob Summerwill as host/interviewer, Kieren James-Lubin as co-host, a moderator, and one minor speaker at the end)
+- **Transcriber bases**: 3 (AssemblyAI, WhisperX local, WhisperX Cloud)
+- **AI processors assessed**: 3 (Opus, Gemini, Grok)
+- **Total output files**: 9 processor outputs assessed
 
 ---
 
-## 1. Transcriber Comparison
+## 1. Transcriber Quality Assessment
 
-| Transcriber | Word Count | Line Count | Speakers | Diarization Quality | Timestamp Granularity | Notes |
-|---|---|---|---|---|---|---|
-| WhisperX (local) | 10,459 | 188 | 5 (SPEAKER_00-04, UNKNOWN) | Good -- 5 distinct speakers with reasonable separation | Per-speaker-turn | Best diarization of the three; correctly separates Bob (SPEAKER_02) from others; short interjections preserved |
-| WhisperX Cloud | 10,401 | 94 | 4 (SPEAKER_00-03) | Poor -- Only 4 speakers detected; merges speakers aggressively | Per-speaker-turn but merged | Collapses multiple speakers into fewer labels; long wall-of-text paragraphs; Bob and the moderator appear merged |
-| AssemblyAI | 10,637 | 262 | 4 (SPEAKER_00-03) | Good -- 4 distinct speakers with fine-grained turn-taking | Very granular per-utterance | Best timestamp granularity; captures short interjections ("Yeah", "Really?") as separate turns; slightly fewer speaker IDs but cleaner separation |
+### Raw Transcriber Statistics
 
-### Transcriber Quality Notes
+| Transcriber | Word Count | Speaker Labels | Diarization Quality |
+|---|---|---|---|
+| AssemblyAI | 10,637 | 4 (SPEAKER_00-03) | Good -- granular turn-taking, 262 lines, captures short interjections as separate turns |
+| WhisperX (local) | 10,459 | 5 (SPEAKER_00-04, UNKNOWN) | Good -- best speaker count, 188 lines, correctly identifies 5th speaker |
+| WhisperX Cloud | 10,401 | 4 (SPEAKER_00-03) | Poor -- only 94 lines, aggressive speaker merging, wall-of-text paragraphs |
 
-**WhisperX (local)**: Strongest diarization with 5 speaker labels and an UNKNOWN label. Maintains reasonable paragraph separation. Timestamps are accurate and per-turn. Some minor ASR artifacts ("Meyer's couple" for Meierskappel, "Zoog" for Zug, "Mihai Lissier" for Mihai Alisie). Overall the most usable raw transcript for downstream processing.
+### Transcriber Details
 
-**WhisperX Cloud**: Weakest of the three. Only 4 speaker labels with aggressive merging of consecutive speech. Lines 1-94 represent the entire transcript compressed into very long paragraphs, with speaker attribution errors (e.g., multiple speakers' dialogue combined under a single label). The low line count (94 vs 188/262 for the others) reflects this compression.
+**AssemblyAI**: The most granular raw transcription. Each short utterance ("Yeah", "Really?", "Who knows?") gets its own timestamped line, resulting in the highest line count (262). Speaker labels are consistent and well-separated throughout. Minor ASR artifacts include "Taylor Gowering" for Taylor Gerring, "Meyer Scoppel" for Meierskappel, "Mihaly Lisier" for Mihai Alisie. Timestamps begin at [02:14], suggesting a 2-minute offset from the recording start. No corruption detected -- the transcript is clean and well-structured from start to finish.
 
-**AssemblyAI**: Very granular turn-taking with 262 lines (most individual utterances get their own timestamp). 4 speaker labels but well-separated. Minor ASR issues similar to WhisperX local ("Taylor Gowering" for Taylor Gerring, "Zoo" for Zug). The consensus variant (assemblyai_consensus) adds ~400 words of additional detail at 11,051 words.
+**WhisperX (local)**: Detects 5 distinct speakers plus an UNKNOWN label, making it the only transcriber to correctly identify all participants. Line count of 188 represents a good middle ground between granularity and readability. Timestamps are well-aligned. Similar ASR artifacts: "Taylor Garrick" for Taylor Gerring, "Meyer's couple" for Meierskappel. Diarization is strong with reasonable turn separation. No corruption or structural issues.
 
-**Verdict**: WhisperX local and AssemblyAI are both strong bases. WhisperX Cloud is the weakest transcriber for this episode due to speaker merging.
+**WhisperX Cloud**: The weakest transcriber for this episode. Only 94 lines total for a 70-minute conversation means extensive speaker merging. Multiple speakers' dialogue is concatenated under single speaker labels, creating wall-of-text paragraphs (some exceeding 1000 words). Speaker attribution errors are present -- for example, lines 1-9 compress the opening remarks of 4 speakers into a single SPEAKER_00 block. The low line count and aggressive merging make it the least reliable base for downstream processing.
 
----
-
-## 2. AI Processor Comparison -- AssemblyAI Base
-
-| Processor | Word Count | % of Max | Tier | Speaker Labels | Name Corrections | Formatting | Prose Quality | Key Issues |
-|---|---|---|---|---|---|---|---|---|
-| GLM | 23,946 | 100% | **Tier 4** | N/A | N/A | **BROKEN** | N/A | Output is NOT a transcript -- it is a massive chain-of-thought analysis document (planning notes, corrections list, reasoning). No actual transcript produced. Completely unusable. |
-| Kimi | 10,632 | 44% | Tier 2 | Correct | Good | Good | Good | Complete transcript, clean formatting, proper names corrected. Slightly condensed. |
-| Gemini | 10,261 | 43% | **Tier 1** | Correct | Excellent | Excellent | Excellent | Proper name corrections (Mihai Alisie, Jeff Wilcke, ConsenSys, Nick Szabo, Meierskappel). Clean paragraph formatting. Timestamps adjusted to remove 2-min offset. Complete coverage. |
-| Opus | 10,256 | 43% | **Tier 1** | Correct | Excellent | Excellent | Excellent | Proper name corrections (Mihai Alisie, Jeff Wilcke, Anthony Di Iorio, Nick Szabo, Meierskappel). Clean, professional formatting. Full coverage to end. Natural prose. |
-| Grok | 10,082 | 42% | Tier 2 | Correct | Good | Good | Good | Complete, clean. Minor name issues. Solid mid-tier output. |
-| ChatGPT | 9,893 | 41% | Tier 2 | Correct | Good | Good | Good | Complete, well-formatted. Slightly more filler retained than Opus/Gemini. |
-| Llama | 6,291 | 26% | Tier 3 | Correct | Fair | Good | Fair | Significant condensation but retains raw transcript feel; fewer name corrections; leaves "Mihaly Lisier", "Taylor Gowering" uncorrected. |
-| DeepSeek | 6,271 | 26% | Tier 2 | Correct | Good | Good | Good | Aggressively cleaned filler words, resulting in tighter prose but at cost of ~40% word reduction. Good name corrections. Complete topical coverage despite lower word count. |
-| Qwen | 5,964 | 25% | Tier 3 | Correct | Fair | Good | Fair | Significant condensation. Retains structure but loses nuance. |
-| Mistral | 5,530 | 23% | Tier 3 | Correct | Fair | Fair | Fair | Heavy condensation. Some formatting inconsistencies. |
-| MiniMax | 3,098 | 13% | **Tier 4** | Correct | Poor | **BROKEN** | Poor | Output is a wall of text -- all speaker turns concatenated without paragraph breaks. No line separation between speakers. Name corrections minimal ("Anthony D'Onofrio" for Anthony Di Iorio). Essentially unusable formatting. |
+**Verdict**: AssemblyAI and WhisperX local are both strong transcriber bases. AssemblyAI offers the best granularity; WhisperX local offers the best speaker detection. WhisperX Cloud is significantly weaker due to speaker merging.
 
 ---
 
-## 3. AI Processor Comparison -- WhisperX (Local) Base
+## 2. AI Processor Assessment -- AssemblyAI Base
 
-| Processor | Word Count | % of Max | Tier | Speaker Labels | Name Corrections | Formatting | Prose Quality | Key Issues |
-|---|---|---|---|---|---|---|---|---|
-| GLM | 24,307 | 100% | **Tier 4** | N/A | N/A | **BROKEN** | N/A | Same problem as AssemblyAI GLM: output is chain-of-thought reasoning, not a transcript. Completely unusable. |
-| Kimi | 10,419 | 43% | Tier 2 | Correct | Good | Good | Good | Complete, clean. Solid mid-tier. |
-| Grok | 10,287 | 42% | Tier 2 | Correct | Good | Good | Good | Complete, well-formatted. |
-| Gemini | 10,235 | 42% | **Tier 1** | Correct | Excellent | Excellent | Excellent | Same high quality as AssemblyAI Gemini. Excellent name corrections and formatting. |
-| Opus | 10,192 | 42% | **Tier 1** | Correct | Excellent | Excellent | Excellent | Clean, complete, excellent name corrections. Timestamps properly preserved. Uses correct Meierskappel, Mihai Alisie, Nick Szabo, etc. |
-| ChatGPT | 9,718 | 40% | Tier 2 | Correct | Good | Good | Good | Complete, solid output. |
-| Llama | 6,895 | 28% | Tier 3 | Correct | Fair | Good | Fair | Condensed but complete topical coverage. |
-| DeepSeek | 6,507 | 27% | Tier 2 | Correct | Good | Good | Good | Same pattern as AssemblyAI DeepSeek -- tight prose, aggressive filler removal. |
-| Qwen | 6,228 | 26% | Tier 3 | Correct | Fair | Good | Fair | Condensed. |
-| Mistral | 5,901 | 24% | Tier 3 | Correct | Fair | Fair | Fair | Heavy condensation. |
-| MiniMax | 4,428 | 18% | Tier 3 | Correct | Fair | Fair | Fair | Better than AssemblyAI MiniMax (has paragraph breaks) but still quite condensed. |
+| Processor | Word Count | Lines | % of Max | Tier | Rating |
+|---|---|---|---|---|---|
+| Gemini | 10,261 | 234 | 100% | **Tier 1** | Excellent |
+| Opus | 10,256 | 218 | ~100% | **Tier 1** | Excellent |
+| Grok | 10,082 | 228 | 98% | **Tier 1** | Excellent |
 
----
+### AssemblyAI + Opus (10,256 words, 218 lines)
 
-## 4. AI Processor Comparison -- WhisperX Cloud Base
+**Completeness**: Full coverage from [02:14] to [01:11:13]. All content present including the opening technical difficulties, main interview, and closing remarks. No truncation.
 
-| Processor | Word Count | % of Max | Tier | Speaker Labels | Name Corrections | Formatting | Prose Quality | Key Issues |
-|---|---|---|---|---|---|---|---|---|
-| GLM | 14,297 | 100% | **Tier 4** | N/A | N/A | **BROKEN** | N/A | Chain-of-thought reasoning dump, not a transcript. |
-| Kimi | 10,401 | 73% | Tier 2 | Correct | Good | Good | Good | Complete, clean. |
-| Gemini | 10,283 | 72% | **Tier 1** | Correct | Excellent | Excellent | Excellent | Same high quality pattern. |
-| Grok | 10,196 | 71% | Tier 2 | Correct | Good | Good | Good | Solid output. |
-| Opus | 9,909 | 69% | **Tier 1** | Correct | Excellent | Excellent | Excellent | High quality despite weaker transcriber base. |
-| ChatGPT | 9,415 | 66% | Tier 2 | Correct | Good | Good | Good | Complete, well-formatted. |
-| Llama | 6,834 | 48% | Tier 3 | Correct | Fair | Good | Fair | Condensed. |
-| DeepSeek | 6,724 | 47% | Tier 2 | Correct | Good | Good | Good | Tight prose, good corrections. |
-| Qwen | 6,442 | 45% | Tier 3 | Correct | Fair | Good | Fair | Condensed. |
-| Mistral | 6,410 | 45% | Tier 3 | Correct | Fair | Fair | Fair | Condensed, some formatting issues. |
-| MiniMax | 5,907 | 41% | Tier 3 | Correct | Fair | Fair | Fair | Better than AssemblyAI MiniMax but still quite condensed. |
+**Name corrections**: Excellent. Correctly renders Taylor Gerring, Mihai Alisie (from "Mihaly Lisier"), Jeff Wilcke, Anthony Di Iorio, Charles Hoskinson, Jonathan Mohan, Nick Szabo, ConsenSys, Wendell Davis, Stefan Tual. Meyerskoppel is close but not the standard spelling (should be Meierskappel).
 
----
+**Formatting**: Clean paragraph structure with proper speaker separation. Short interjections preserved as separate turns. Timestamps from the raw transcription are faithfully preserved. Professional, readable output.
 
-## 5. Consensus Pipeline Status
+**Prose quality**: Natural and fluid. Appropriate filler removal -- retains enough conversational markers to sound authentic while removing distracting verbal noise. Handles Taylor's long narrative passages well without losing flow.
 
-**No `_final.md` file exists.** The consensus pipeline has not been run for this episode.
+**Diarization handling**: Maintains the 4-speaker AssemblyAI labels without introducing errors. Speaker turns are clean and properly attributed throughout.
 
-An `assemblyai_consensus.md` intermediate file exists (11,051 words), which appears to be a word-level consensus merge between transcribers, but this has not been processed through the full consensus pipeline to produce a final output.
+**Timestamp behavior**: Preserves original AssemblyAI timestamps starting at [02:14]. Does not adjust the offset.
 
-A `REVIEW_EXCERPTS.md` file exists with automated comparison metrics for the Opus and Gemini processors against the AssemblyAI base.
+### AssemblyAI + Gemini (10,261 words, 234 lines)
 
----
+**Completeness**: Full coverage from [00:00] to [51:14]. All content present, no truncation.
 
-## 6. Cross-Transcriber Comparison
+**Name corrections**: Excellent. Taylor Gerring, Mihai Alisie, Jeff Wilcke, Anthony Di Iorio, Nick Szabo, Meierskappel (correct spelling), ConsenSys, EthStats. Very strong on proper noun accuracy.
 
-Comparing the same AI processor across different transcriber bases reveals:
+**Formatting**: Clean and professional. Slightly more lines than Opus (234 vs 218) because Gemini breaks some compound turns into separate lines. Good paragraph structure.
 
-### Opus Processor Across Bases
-| Base | Words | Name "Gerring" | Place Name | Mihai Alisie | Nick Szabo | Timestamps |
-|---|---|---|---|---|---|---|
-| AssemblyAI | 10,256 | "Taylor Gerring" (correct) | "Meyerskoppel" | "Mihai Alisie" (correct) | "Nick Szabo" (correct) | Original preserved |
-| WhisperX | 10,192 | "Taylor Gerring" (correct) | "Meierskappel" (correct) | "Mihai Alisie" (correct) | "Nick Szabo" (correct) | Original preserved |
-| WhisperX Cloud | 9,909 | "Taylor Gerring" (correct) | "Meyer Scoppel" | "Mihai Alisie" (correct) | "Nick Szabo" (correct) | Original preserved |
+**Prose quality**: Excellent. Natural conversational flow preserved. Handles the multi-speaker dynamic well.
 
-### Gemini Processor Across Bases
-| Base | Words | Name "Gerring" | Place Name | Timestamps |
-|---|---|---|---|---|
-| AssemblyAI | 10,261 | "Taylor Gerring" (correct) | "Meierskappel" (correct) | Adjusted (offset removed) |
-| WhisperX | 10,235 | "Taylor Gerring" (correct) | "Meierskappel" (correct) | Adjusted (offset removed) |
-| WhisperX Cloud | 10,283 | "Taylor Garing" (varies) | "Meyer Scoppel" | Adjusted |
+**Timestamp behavior**: Notably, Gemini removes the ~2-minute offset present in the AssemblyAI raw transcript, starting at [00:00] instead of [02:14]. This results in different timestamp values throughout. The last timestamp is [51:14] instead of [01:11:13]. This suggests Gemini interprets the offset as an artifact and normalizes it, which may or may not be desired depending on whether the original recording has preamble audio.
 
-**Key Observations**:
-- Opus and Gemini produce consistently high-quality outputs regardless of transcriber base
-- The AssemblyAI base produces slightly longer outputs across most processors, likely due to its more granular turn-taking
-- WhisperX local provides the best proper noun accuracy for downstream processors
-- WhisperX Cloud's speaker merging issues propagate into outputs but top-tier processors handle them gracefully
+**Notable difference from Opus**: The timestamp adjustment is the primary distinguishing factor. Gemini's place name accuracy is marginally better (Meierskappel vs Meyerskoppel).
+
+### AssemblyAI + Grok (10,082 words, 228 lines)
+
+**Completeness**: Full coverage from [02:14] to [01:11:13]. No truncation. Slightly fewer words than Opus/Gemini but difference is minimal (~2%).
+
+**Name corrections**: Good. Correctly renders Taylor Gerring (though one instance as "Taylor Gowing" in line 15), Mihai Alisie, Nick Szabo, ConsenSys. Place name rendered as "Meyershoppel". Slightly less consistent than Opus/Gemini on proper nouns.
+
+**Formatting**: Clean with proper speaker separation. Comparable structure to Opus. Good readability.
+
+**Prose quality**: Good. Slightly less polished than Opus/Gemini in filler word handling -- some passages retain more conversational roughness. Overall still very readable and faithful to the source.
+
+**Diarization handling**: Clean 4-speaker labels, no attribution errors detected.
+
+**Timestamp behavior**: Preserves original AssemblyAI timestamps, same as Opus.
 
 ---
 
-## 7. Detailed Quality Notes
+## 3. AI Processor Assessment -- WhisperX (Local) Base
 
-### GLM (All Bases) -- Critical Failure
-All three GLM outputs are **completely broken**. Instead of producing a cleaned transcript, GLM outputs its entire chain-of-thought reasoning process, including analysis steps, correction notes, name lookup tables, and line-by-line editing commentary. The WhisperX GLM file is 24,307 words of internal reasoning with zero usable transcript. This is a systematic failure of the GLM model to follow the output format instructions.
+| Processor | Word Count | Lines | % of Max | Tier | Rating |
+|---|---|---|---|---|---|
+| Grok | 10,287 | 184 | 100% | **Tier 1** | Excellent |
+| Gemini | 10,235 | 190 | ~100% | **Tier 1** | Excellent |
+| Opus | 10,192 | 198 | 99% | **Tier 1** | Excellent |
 
-### MiniMax (AssemblyAI) -- Formatting Failure
-The AssemblyAI MiniMax output (3,098 words) outputs the entire transcript as a single wall of text with no paragraph breaks between speakers. While the content appears largely present, the lack of formatting makes it unusable as a readable transcript.
+### WhisperX + Opus (10,192 words, 198 lines)
 
-### Opus -- Benchmark Quality
-The Opus processor consistently produces the best outputs across all three bases:
-- Correct proper name spellings (Mihai Alisie, Jeff Wilcke, Anthony Di Iorio, Charles Hoskinson, Nick Szabo, ConsenSys)
-- Clean paragraph formatting with proper speaker separation
-- Natural prose flow with appropriate filler removal
-- Complete coverage from start (02:14) to end (1:11:08)
-- Correct technical terms (dapp, devp2p, Yellow Paper, EVM, Geth, cpp-ethereum)
+**Completeness**: Full coverage from [02:14] to [01:05:36]. All content present, no truncation. The 5-speaker WhisperX labels (SPEAKER_00-04) are preserved, which is an advantage over the AssemblyAI base.
 
-### Gemini -- Near-Benchmark Quality
-Gemini produces outputs comparable to Opus, with one notable difference: it adjusts timestamps (removing a ~2-minute offset in some cases). This may or may not be desirable depending on whether the offset is an artifact. Name corrections are equally excellent.
+**Name corrections**: Excellent. Same high standard as AssemblyAI Opus. Correctly renders all major names. Place name as "Meyershoppel" -- similar to AssemblyAI variant.
 
-### DeepSeek -- Efficient Condensation
-Despite lower word counts (~6,200-6,700), DeepSeek produces surprisingly readable outputs. It aggressively removes filler words while preserving all substantive content. For use cases where conciseness is valued, DeepSeek may actually be preferable to full-length outputs.
+**Formatting**: Clean, well-structured. The 5-speaker labeling from WhisperX local allows for better speaker attribution in the final output.
+
+**Prose quality**: Excellent. Natural flow, appropriate filler removal.
+
+**Diarization handling**: Successfully maintains the 5-speaker differentiation. This is the version that best preserves the distinction between the moderator (SPEAKER_03 or equivalent) and other speakers.
+
+### WhisperX + Gemini (10,235 words, 190 lines)
+
+**Completeness**: Full coverage. Same high quality as other Gemini outputs.
+
+**Name corrections**: Excellent. Meierskappel correctly spelled (benefiting from WhisperX local's better ASR of this word).
+
+**Formatting**: Clean and professional.
+
+**Timestamp behavior**: Preserves WhisperX timestamps without offset adjustment in this case.
+
+### WhisperX + Grok (10,287 words, 184 lines)
+
+**Completeness**: Full coverage. Highest word count of the WhisperX outputs, suggesting slightly less aggressive filler removal.
+
+**Name corrections**: Good. Consistent with AssemblyAI Grok quality.
+
+**Formatting**: Clean, readable. Good speaker separation.
+
+---
+
+## 4. AI Processor Assessment -- WhisperX Cloud Base
+
+| Processor | Word Count | Lines | % of Max | Tier | Rating |
+|---|---|---|---|---|---|
+| Gemini | 10,283 | 152 | 100% | **Tier 1** | Excellent |
+| Grok | 10,196 | 92 | 99% | **Tier 2** | Good |
+| Opus | 9,909 | 180 | 96% | **Tier 1** | Excellent |
+
+### WhisperX Cloud + Opus (9,909 words, 180 lines)
+
+**Completeness**: Full coverage from [02:14] to [01:05:36]. Slightly lower word count (9,909) than the other Opus variants, likely due to the WhisperX Cloud base providing less granular source material. However, no content is missing -- the difference is in how the speaker-merged paragraphs are decomposed.
+
+**Name corrections**: Excellent. Same standard as other Opus outputs. Correctly identifies Pyethereum, DevP2P, DevCon terminology.
+
+**Formatting**: Notably, Opus does an excellent job of un-merging the speaker-compressed paragraphs from the WhisperX Cloud base. Despite the raw input having only 94 lines of wall-of-text, the Opus output has 180 well-separated lines. This demonstrates Opus's ability to reconstruct speaker turn boundaries even when the input has poor diarization.
+
+**Prose quality**: Excellent. The quality is only marginally lower than the AssemblyAI or WhisperX local Opus outputs, despite the significantly weaker base.
+
+### WhisperX Cloud + Gemini (10,283 words, 152 lines)
+
+**Completeness**: Full coverage. Word count comparable to the other Gemini variants.
+
+**Name corrections**: Good. Renders "Taylor Garing" in at least one instance (carried from the Cloud base's ASR error), whereas the other Gemini variants correctly render "Gerring". This demonstrates that even top-tier processors can propagate base-level ASR errors.
+
+**Formatting**: Clean but fewer lines (152) than Opus (180), suggesting Gemini was less aggressive in breaking apart the merged paragraphs.
+
+### WhisperX Cloud + Grok (10,196 words, 92 lines)
+
+**Completeness**: Full coverage in terms of word count, but the extremely low line count (92) is concerning. This matches the raw WhisperX Cloud line count almost exactly, meaning Grok did NOT decompose the merged speaker paragraphs. The output preserves the wall-of-text formatting of the source, with massive paragraphs containing multiple speakers' dialogue.
+
+**Name corrections**: Good for names it can identify, but the merged paragraph structure makes speaker attribution unreliable.
+
+**Formatting**: Poor. Wall-of-text paragraphs inherited directly from the source. This is the weakest output of all 9 assessed files. While the content is present, the readability is significantly compromised.
+
+**Notable issue**: Grok failed to reconstruct speaker turn boundaries from the merged Cloud base. Opus and Gemini both partially or fully succeeded at this task. This represents a meaningful quality gap for Grok specifically when working with poorly diarized inputs.
+
+---
+
+## 5. Cross-Transcriber Side-by-Side Comparison
+
+### Same Passage Across All Three Transcriber Bases (Taylor's Bitcoin discovery, ~[08:56])
+
+**AssemblyAI raw**: "I discovered Bitcoin I want to say in 2011 I, I when I was clearing off a laptop I saw I had the bitcoin software downloaded but it was still in testnet mode. I never, I never figured out how to get it out of test net mode until when I really discovered the second time in 2012..."
+
+**WhisperX local raw**: "I discovered Bitcoin, I want to say in 2011. When I was clearing off a laptop, I... So I had the Bitcoin software downloaded, but it was still in testnet mode. I never figured out how to get out of testnet mode until when I really discovered the second time in 2012..."
+
+**WhisperX Cloud raw**: "I discovered Bitcoin, I want to say in 2011. When I was clearing off a laptop, I... So I had the Bitcoin software downloaded, but it was still in testnet mode. I never figured out how to get out of testnet mode until when I really discovered the second time in 2012 and going into 2013."
+
+**Observations**: All three transcribers capture the same content accurately. The differences are minor (punctuation, filler words). Content fidelity is equivalent across bases for this passage.
+
+### Speaker Attribution Comparison (Opening segment, ~[02:14]-[03:14])
+
+**AssemblyAI**: 7 separate speaker turns, 4 speakers correctly identified. Each utterance ("That little flub", "Fantastic", "All here. Hello") gets its own line.
+
+**WhisperX local**: 3 separate speaker turns, 3 speakers identified. Groups the very short utterances together. Speaker attribution matches content.
+
+**WhisperX Cloud**: 1 speaker turn. All opening remarks from 4 speakers compressed into a single SPEAKER_00 block: "that little love. Fantastic. All here. Hello. Hello. We are back. Great. Yeah..." This is a clear diarization failure.
+
+### Name Rendering Comparison
+
+| Name | AssemblyAI | WhisperX Local | WhisperX Cloud |
+|---|---|---|---|
+| Taylor Gerring | "Taylor Gowering" | "Taylor Garrick" | "Taylor Garing" |
+| Mihai Alisie | "Mihaly Lisier" | "Mihai Lissier" | "Mihaly Lissier" |
+| Meierskappel | "Meyer Scoppel" | "Meyer's couple" | "Meyer Scoppel" |
+| Nick Szabo | (not in first 100 lines) | (not in first 100 lines) | (not in first 100 lines) |
+| Jeff Wilcke | "Jeff Wilkie" | "Jeff Wilkie" | "Jeff Wilcke" |
+
+**Observations**: All three transcribers struggle with the same proper nouns, particularly foreign names and Swiss place names. WhisperX Cloud gets "Jeff Wilcke" closest to correct. AI processors correct these systematically.
+
+---
+
+## 6. Processor Tier Summary
+
+### Tier Definitions
+- **Tier 1**: Complete (>90% of max word count), excellent name corrections, excellent formatting, excellent prose quality
+- **Tier 2**: Mostly complete (>75% of max), good corrections and formatting
+- **Tier 3**: Truncated or significantly condensed (<50% of max)
+- **Tier 4**: Unusable (corruption, formatting failure, or non-transcript output)
+
+### Results Matrix
+
+| Processor | AssemblyAI Base | WhisperX Base | WhisperX Cloud Base |
+|---|---|---|---|
+| **Opus** | Tier 1 (10,256w) | Tier 1 (10,192w) | Tier 1 (9,909w) |
+| **Gemini** | Tier 1 (10,261w) | Tier 1 (10,235w) | Tier 1 (10,283w) |
+| **Grok** | Tier 1 (10,082w) | Tier 1 (10,287w) | Tier 2 (10,196w) |
+
+All three processors achieve Tier 1 on the AssemblyAI and WhisperX local bases. The distinguishing factor is the WhisperX Cloud base, where Grok drops to Tier 2 due to its failure to decompose merged speaker paragraphs (92 lines of wall-of-text formatting).
+
+---
+
+## 7. Key Findings
+
+### Processor Ranking (Overall)
+1. **Opus** -- Most consistent across all three bases. Excellent at reconstructing speaker turns from poorly diarized input (WhisperX Cloud: 94 raw lines -> 180 output lines). Best prose quality and name corrections. Preserves original timestamps.
+2. **Gemini** -- Comparable to Opus in quality. Marginally better place name accuracy (Meierskappel). Notable timestamp offset adjustment behavior that may or may not be desired. Slightly less effective at un-merging WhisperX Cloud paragraphs than Opus.
+3. **Grok** -- Strong on well-diarized bases (AssemblyAI, WhisperX local). Falls behind on poorly diarized input (WhisperX Cloud). Slightly less consistent name corrections. Still a high-quality processor overall.
+
+### Transcriber Ranking
+1. **AssemblyAI** -- Best granularity, most lines, good diarization. Ideal primary base.
+2. **WhisperX (local)** -- Best speaker detection (5 speakers), good structure. Ideal secondary base.
+3. **WhisperX Cloud** -- Aggressive speaker merging makes it the weakest base. Only top-tier processors (Opus, Gemini) can partially compensate for its limitations.
+
+### Best Outputs for Final Transcript
+1. **`episode004-taylor-gerring_assemblyai_opus.md`** -- Best overall combination of completeness, accuracy, formatting, and natural prose
+2. **`episode004-taylor-gerring_whisperx_opus.md`** -- Best speaker differentiation (5 speakers preserved)
+3. **`episode004-taylor-gerring_assemblyai_gemini.md`** -- Excellent quality with best place name accuracy, but timestamp offset adjustment is a consideration
+4. **`episode004-taylor-gerring_whisperx_gemini.md`** -- Strong alternative combining WhisperX diarization with Gemini's name accuracy
 
 ---
 
 ## 8. Recommendations
 
-### Immediate Actions
-1. **Discard GLM outputs** -- All three are unusable chain-of-thought dumps. The GLM model should be evaluated for instruction-following compliance before being used on future episodes.
-2. **Discard AssemblyAI MiniMax output** -- Wall-of-text formatting makes it unusable. The WhisperX MiniMax outputs have proper formatting and should be preferred.
-3. **Run consensus pipeline** -- No `_final.md` exists. The best outputs (Opus and Gemini across AssemblyAI and WhisperX local bases) should be fed into the consensus pipeline.
-
-### Best Outputs for Final Transcript
-Ranked by overall quality:
-1. **`episode004-taylor-gerring_assemblyai_opus.md`** -- Best combination of completeness, name accuracy, formatting, and natural prose
-2. **`episode004-taylor-gerring_assemblyai_gemini.md`** -- Equally excellent, minor timestamp adjustment difference
-3. **`episode004-taylor-gerring_whisperx_opus.md`** -- Excellent quality, WhisperX base provides best place name accuracy ("Meierskappel")
-4. **`episode004-taylor-gerring_whisperx_gemini.md`** -- Strong alternative
-
-### Transcriber Recommendations
-- **Primary base**: AssemblyAI (best granularity, good diarization)
-- **Secondary base**: WhisperX local (best diarization with 5 speakers, good place name accuracy)
-- **Avoid**: WhisperX Cloud for this episode (speaker merging issues)
-
-### Processor Tier Summary
-- **Tier 1** (Recommended): Opus, Gemini
-- **Tier 2** (Acceptable): ChatGPT, Grok, Kimi, DeepSeek
-- **Tier 3** (Limited value): Llama, Qwen, Mistral, MiniMax (WhisperX variants)
-- **Tier 4** (Unusable): GLM (all bases), MiniMax (AssemblyAI base)
+1. **Primary transcript**: Use `assemblyai_opus.md` as the primary base for any final transcript production. It offers the best balance of all quality metrics.
+2. **Cross-reference**: Use `whisperx_opus.md` for speaker attribution verification, since WhisperX local detects 5 speakers versus AssemblyAI's 4.
+3. **Place name verification**: Cross-reference with Gemini outputs for proper noun accuracy, particularly for the Swiss place name Meierskappel.
+4. **Avoid WhisperX Cloud + Grok**: The `whisperx-cloud_grok.md` output (92 lines) inherits the Cloud base's wall-of-text formatting and should not be used without reformatting.
+5. **Consensus pipeline**: A consensus merge between the top outputs (assemblyai_opus, whisperx_opus, assemblyai_gemini) would likely produce the strongest possible final transcript.

--- a/outputs/episode005-anthony-d-onofrio/episode005-anthony-d-onofrio_quality_assessment.md
+++ b/outputs/episode005-anthony-d-onofrio/episode005-anthony-d-onofrio_quality_assessment.md
@@ -1,161 +1,211 @@
-# Episode 005 (Anthony Di Onofrio) -- Quality Assessment Report
+# Episode 005 (Anthony D'Onofrio) -- Quality Assessment Report
 
 ## Episode Summary
 
-A Twitter Spaces conversation featuring Texture (Anthony D'Onofrio), an early Ethereum contributor, interviewed by Bob Summerwill with co-host Kieren James-Lubin and host Jamie. Topics cover Texture's pre-Ethereum background (Peace Love Human, community building), his discovery of the Ethereum white paper through Adam B. Levine, the early Ethereum Skype group, the Miami house, Charles Hoskinson's behavior, the Red Wedding, Ethereum Foundation politics, and the foundation's governance through multiple leadership epochs.
+A Twitter Spaces conversation featuring Texture (Anthony D'Onofrio), an early Ethereum contributor, interviewed by Bob Summerwill (SPEAKER_00) with co-host Kieran James-Lubin (SPEAKER_02/SPEAKER_00 in whisperx-cloud) and host Jamie (SPEAKER_01). Topics cover Texture's pre-Ethereum background (Peace Love Human, community building, accidental cult), his discovery of the Ethereum white paper through Adam B. Levine, the early Ethereum Skype group, the Miami house, Charles Hoskinson's behavior and eventual departure, the Red Wedding, Ethereum Foundation palace politics, and the foundation's governance through multiple leadership epochs (Ming dynasty, Aya's Infinite Garden, Tomas era).
 
 ---
 
-## 1. Transcriber Comparison
+## 1. Transcriber Quality Assessment
 
-| Transcriber | Word Count | Diarization Quality | Timestamp Format | Key Issues |
-|---|---|---|---|---|
-| **WhisperX (local)** | 14,374 | 4 speakers (SPEAKER_00-03) + UNKNOWN. Good separation but some speaker confusion between SPEAKER_01/03 in early section. Long monologues well-captured. | `[MM:SS]` | "Chad GPT" uncorrected; "PFT texture" not corrected; some lowercase passages; occasional missed diarization boundaries |
-| **WhisperX (cloud)** | 14,156 | 7 speakers (SPEAKER_00-06). Severely collapsed diarization: multiple speakers merged into single long blocks, especially SPEAKER_03 and SPEAKER_06 containing huge multi-speaker monologues. | `[MM:SS]` | Worst diarization of the three; long multi-speaker blocks attributed to single speaker; "Chad GPT"; critical speaker boundary errors throughout |
-| **AssemblyAI** | 14,986 | 5 speakers (SPEAKER_00-04). Best diarization: fine-grained turn-taking with short, accurate segments. SPEAKER_03/04 split for Texture (common ASR issue) but still accurate per-utterance. | `[MM:SS]` | Texture split across SPEAKER_03/04 (frequent alternation); otherwise cleanest diarization with most granular speaker turns |
-| **AssemblyAI consensus** | 15,472 | Same structure as AssemblyAI base. Appears to be a consensus-enriched version. | `[MM:SS]` | Slightly higher word count suggesting filler retention; same SPEAKER_03/04 split |
+### Raw Transcriber Files
 
-**Transcriber Ranking:** AssemblyAI > WhisperX (local) > WhisperX (cloud)
+| Transcriber | File | Words | Speakers Detected |
+|---|---|---|---|
+| AssemblyAI | `intermediates/.../episode005-anthony-d-onofrio_assemblyai.md` | 14,986 | 5 (SPEAKER_00-04) |
+| WhisperX (local) | `intermediates/.../episode005-anthony-d-onofrio_whisperx.md` | 14,374 | 4 (SPEAKER_00-03) + UNKNOWN |
+| WhisperX (cloud) | `intermediates/.../episode005-anthony-d-onofrio_whisperx-cloud.md` | 14,156 | 7 (SPEAKER_00-06) |
 
-AssemblyAI provides the best diarization with fine-grained speaker turn boundaries, despite the SPEAKER_03/04 split for Texture. WhisperX local is acceptable but merges some turns. WhisperX cloud has the worst diarization with massive multi-speaker blocks erroneously attributed to single speakers.
+### Diarization Quality
 
----
+**AssemblyAI** -- Best diarization of the three. Provides fine-grained turn-taking with short, accurately bounded segments. Individual utterances like "Okay," "Yes," and brief interjections get their own properly-attributed lines. The main issue is Texture being split across SPEAKER_03 and SPEAKER_04 (frequent alternation within the same speech), which is a known ASR limitation for speakers with varied vocal patterns. Despite this, each individual turn boundary is accurate and speaker attribution within turns is correct.
 
-## 2. AI Processor Comparison
+**WhisperX (local)** -- Acceptable diarization. Uses 4 main speakers (SPEAKER_00-03) plus an occasional UNKNOWN tag. Speaker separation is generally correct, though some minor confusion exists between SPEAKER_01 and SPEAKER_03 in early sections. Long monologues are well-captured. Some passages collapse to lowercase without capitalization, and there is occasional merging of short turns from different speakers into a single block.
 
-### 2a. AssemblyAI-based outputs
+**WhisperX (cloud)** -- Worst diarization by a significant margin. Despite detecting 7 speaker labels, it has severely collapsed diarization where massive multi-speaker blocks are erroneously attributed to a single speaker. SPEAKER_00 and SPEAKER_03 contain huge multi-speaker monologues. For example, SPEAKER_00 at [03:55] contains a 700+ word block spanning dialogue from at least 4 different people (Jamie, Bob, Kieran, Texture). Similar collapse occurs with SPEAKER_03 containing enormous wall-of-text passages. This makes it extremely difficult for AI processors to correctly attribute dialogue.
 
-| Processor | Words | % of Max | Tier | Timestamps | Speaker Labels | Prose Quality | Key Issues |
-|---|---|---|---|---|---|---|---|
-| **Grok** | 14,978 | 100% | 1 | Preserved original `[MM:SS]` | Preserved SPEAKER_00-04 split | Good preservation of all dialogue, clean formatting | Retains most filler; "Nevermind" instead of "Nethermind"; faithful to source including errors |
-| **Gemini** | 14,639 | 98% | 1 | Regenerated to `[00:00]` offset (lost original times) | Merged SPEAKER_03/04 into unified SPEAKER_04 | Excellent readability; cleaned fillers well; good paragraph breaks | Timestamps regenerated and offset to 00:00; lost original timeline |
-| **Opus** | 14,308 | 96% | 1 | Preserved original `[MM:SS]` accurately | Preserved SPEAKER_00-04 | Excellent: clean, well-punctuated, natural flow; good filler removal | Very high quality; accurate names; well-merged speaker turns |
-| **Kimi** | 10,450 | 70% | 2 | Preserved | Preserved | Decent quality, some condensation | ~30% content loss; some dialogue trimmed |
-| **ChatGPT** | 5,426 | 36% | 3 | Preserved | Preserved | Reasonable quality but heavily condensed | >60% content loss; significant summarization |
-| **Qwen** | 5,500 | 37% | 3 | Preserved | Preserved | Moderate quality, heavy condensation | >60% content loss; major sections dropped |
-| **MiniMax** | 5,407 | 36% | 3 | Preserved | Preserved | Moderate quality | Heavy condensation |
-| **Llama** | 5,340 | 36% | 3 | Preserved | Preserved | Moderate quality | Heavy condensation |
-| **DeepSeek** | 5,245 | 35% | 3 | Preserved | Preserved | Moderate quality | Heavy condensation |
-| **Mistral** | 4,274 | 29% | 3 | Preserved | Preserved | Lower quality, incomplete | >70% content loss; cuts off or omits heavily |
-| **GLM** | 19,491 | 130% | 4 | N/A | N/A | Unusable: contains massive chain-of-thought preamble, no clean transcript output | Output is internal reasoning/analysis, not a cleaned transcript; includes raw "thinking" text; inflated word count is chain-of-thought, not content |
-
-### 2b. WhisperX (local)-based outputs
-
-| Processor | Words | % of Max | Tier | Timestamps | Speaker Labels | Prose Quality | Key Issues |
-|---|---|---|---|---|---|---|---|
-| **Grok** | 14,374 | 100% | 1 | Preserved | Preserved SPEAKER_00-03 | Faithful preservation; clean | Minor uncorrected terms |
-| **Gemini** | 14,060 | 98% | 1 | Stripped timestamps entirely | Preserved SPEAKER_00-03 | Excellent readability; very clean prose; good dashes/quotes for dialogue | No timestamps at all (stripped); excellent prose quality otherwise |
-| **Opus** | 13,549 | 94% | 1 | Preserved | Preserved | Excellent quality; well-cleaned | High-quality output |
-| **Kimi** | 12,374 | 86% | 1 | Preserved | Preserved | Good quality, slight condensation | Near-complete |
-| **ChatGPT** | 11,815 | 82% | 2 | Preserved | Preserved | Good quality | Some condensation |
-| **Llama** | 6,435 | 45% | 3 | Preserved | Preserved | Moderate | Heavy condensation |
-| **Qwen** | 5,852 | 41% | 3 | Preserved | Preserved | Moderate | Heavy condensation |
-| **DeepSeek** | 5,708 | 40% | 3 | Preserved | Preserved | Moderate | Heavy condensation |
-| **Mistral** | 5,612 | 39% | 3 | Preserved | Preserved SPEAKER_03/04 alternation | Lower quality; fragmented; retains the SPEAKER_03/04 alternation unfixed | Many broken sentence fragments due to unfixed speaker alternation |
-| **MiniMax** | 1,783 | 12% | 4 | Preserved (partial) | Preserved | Severely truncated; only ~72 lines covering first portion of episode | Cuts off extremely early; only covers ~10% of conversation |
-| **GLM** | 32,631 | 227% | 4 | N/A | N/A | Unusable: massive chain-of-thought preamble | Same issue as assemblyai_glm; internal reasoning dominates output |
-
-### 2c. WhisperX (cloud)-based outputs
-
-| Processor | Words | % of Max | Tier | Timestamps | Speaker Labels | Prose Quality | Key Issues |
-|---|---|---|---|---|---|---|---|
-| **Grok** | 14,157 | 100% | 1 | Preserved | Preserved SPEAKER_00-06 | Good faithful preservation | Inherits cloud diarization issues |
-| **Gemini** | 13,898 | 98% | 1 | Preserved | Preserved | Good quality | Inherits cloud diarization issues |
-| **Opus** | 13,349 | 94% | 1 | Preserved | Preserved | Excellent prose quality | Inherits cloud diarization issues |
-| **Kimi** | 12,985 | 92% | 1 | Preserved | Preserved | Good quality | Near-complete |
-| **ChatGPT** | 12,300 | 87% | 2 | Preserved | Preserved | Good quality | Some condensation |
-| **Llama** | 6,713 | 47% | 3 | Preserved | Preserved | Moderate | Heavy condensation |
-| **DeepSeek** | 6,774 | 48% | 3 | Preserved | Preserved | Moderate | Heavy condensation |
-| **Qwen** | 6,250 | 44% | 3 | Preserved | Preserved | Moderate | Heavy condensation |
-| **Mistral** | 6,021 | 43% | 3 | Preserved | Preserved | Moderate | Heavy condensation |
-| **MiniMax** | 5,907 | 42% | 3 | Preserved | Preserved | Moderate | Heavy condensation |
-| **GLM** | 45,813 | 324% | 4 | N/A | N/A | Unusable: massive chain-of-thought preamble (~320 lines before any transcript content) | Worst offender; enormous internal reasoning dump |
+**Transcriber Ranking:** AssemblyAI > WhisperX (local) >> WhisperX (cloud)
 
 ---
 
-## 3. Consensus Pipeline
+## 2. AI Processor Quality Assessment
 
-- **Status:** Partially present
-- **Files:** `episode005-anthony-d-onofrio_assemblyai_consensus.md` (15,472 words) and `episode005-anthony-d-onofrio_assemblyai_consensus_words.json` exist in intermediates
-- **No final consensus file** (`*_final.md`) exists in outputs
-- The consensus intermediate appears to be an enriched version of the AssemblyAI base transcript with slightly higher word count (15,472 vs 14,986), suggesting retention of additional filler words or small corrections
-- The consensus pipeline was started but not completed to final output stage
+### Word Count Summary
 
----
-
-## 4. Cross-Transcriber Comparison
-
-When comparing the same AI processor across different transcriber bases:
-
-### Opus outputs across transcribers
-| Base | Words | Quality Notes |
+| Processor Output | Words | % of Max (14,978) |
 |---|---|---|
-| AssemblyAI | 14,308 | Best diarization; SPEAKER_03/04 split preserved but clearly same person; accurate timestamps |
-| WhisperX local | 13,549 | Good quality; 4 speakers; slightly fewer words due to less granular source |
-| WhisperX cloud | 13,349 | Inherits cloud's poor diarization; long multi-speaker blocks remain unresolved |
+| assemblyai_grok | 14,978 | 100.0% |
+| assemblyai_gemini | 14,639 | 97.7% |
+| assemblyai_opus | 14,308 | 95.5% |
+| whisperx_grok | 14,374 | 96.0% |
+| whisperx_gemini | 14,060 | 93.9% |
+| whisperx_opus | 13,549 | 90.5% |
+| whisperx-cloud_grok | 14,157 | 94.5% |
+| whisperx-cloud_gemini | 13,898 | 92.8% |
+| whisperx-cloud_opus | 13,349 | 89.1% |
 
-### Gemini outputs across transcribers
-| Base | Words | Quality Notes |
-|---|---|---|
-| AssemblyAI | 14,639 | Best combined quality; merged SPEAKER_03/04 into SPEAKER_04; BUT regenerated timestamps to 00:00 offset |
-| WhisperX local | 14,060 | Stripped all timestamps; excellent prose quality with em-dashes and quotation marks for dialogue |
-| WhisperX cloud | 13,898 | Retained timestamps; inherits cloud diarization problems |
+### 2a. AssemblyAI-based Outputs
 
-### Grok outputs across transcribers
-| Base | Words | Quality Notes |
-|---|---|---|
-| AssemblyAI | 14,978 | Highest word retention; very faithful to source; minimal editing |
-| WhisperX local | 14,374 | Near-identical word count to source; minimal processing applied |
-| WhisperX cloud | 14,157 | Faithful to source; inherits diarization issues |
+#### assemblyai_opus (14,308 words, 482 lines)
 
-**Key Cross-Transcriber Findings:**
-1. AssemblyAI-based outputs consistently produce the best results due to superior diarization
-2. WhisperX cloud outputs are penalized by poor source diarization that AI processors mostly cannot fix
-3. Gemini has an inconsistent timestamp handling bug: regenerated in AssemblyAI base, stripped in WhisperX local, preserved in WhisperX cloud
-4. Grok is the most faithful/literal processor across all bases, preserving source structure with minimal editorial intervention
-5. Opus provides the best balance of faithfulness and readability across all bases
+- **Tier: 1 (Complete, Excellent)**
+- **Timestamps:** Preserved original `[MM:SS]` and `[H:MM:SS]` format correctly throughout
+- **Speaker Labels:** Maintained SPEAKER_00-04 designations from source
+- **Diarization Handling:** Faithfully preserved the SPEAKER_03/04 split from the AssemblyAI source; did not attempt to merge them
+- **Prose Quality:** Excellent. Clean formatting with proper sentence structure, capitalization corrected ("ChatGPT" not "Chad GPT"), proper nouns handled well ("PFP" corrected from "Pft", "Texture Punk" from "texture pump")
+- **Completeness:** Full transcript from opening ("Hear me? Can you hear me?") through closing ("Bye"). All content present
+- **Profanity:** Retained where spoken, some instances cleaned ("up" instead of "fucked up")
+- **Notable:** Most polished of the AssemblyAI outputs with best prose refinement while maintaining fidelity
+
+#### assemblyai_gemini (14,639 words, 398 lines)
+
+- **Tier: 1 (Complete, Excellent)**
+- **Timestamps:** Reformatted to shorter format starting from `[00:00]` -- timestamps do NOT match the original audio timecodes. The first speaker entry starts at `[00:00]` instead of `[01:19]`, suggesting Gemini renumbered timestamps from zero
+- **Speaker Labels:** Maintained SPEAKER_00-04 from source
+- **Prose Quality:** Good. Clean formatting. Some stutters/hesitation markers retained more than Opus ("I don't. This is like...")
+- **Completeness:** Full transcript end-to-end
+- **Notable Issue:** The timestamp renumbering from `[00:00]` is a significant deviation. All timestamps in the Gemini output are shifted roughly 1:19 earlier than the actual audio positions. This makes the timestamps unreliable for audio cross-referencing
+
+#### assemblyai_grok (14,978 words, 692 lines)
+
+- **Tier: 1 (Complete, Excellent)**
+- **Timestamps:** Preserved original `[MM:SS]` and `[H:MM:SS]` format matching the source
+- **Speaker Labels:** Maintained SPEAKER_00-04 split from source
+- **Prose Quality:** Good but more verbatim/raw. Retains more filler words, hesitations, and verbal tics. Highest word count reflects most faithful preservation of spoken content
+- **Completeness:** Full transcript end-to-end, highest line count (692) indicating most granular speaker turn preservation
+- **Notable Issues:** "Nevermind" instead of "Nethermind" (misspelling); "FCC" instead of "EthCC"; "Pongsai" instead of "Punks" in some instances. More faithful to source errors but fewer editorial corrections
+- **Formatting:** Most lines are shorter, preserving the fine-grained turn structure from AssemblyAI's diarization
+
+### 2b. WhisperX (local)-based Outputs
+
+#### whisperx_opus (13,549 words, 334 lines)
+
+- **Tier: 1 (Complete, Excellent)**
+- **Timestamps:** Correctly preserved `[MM:SS]` format from source
+- **Speaker Labels:** Maintained SPEAKER_00-03 + occasional UNKNOWN from source
+- **Prose Quality:** Excellent. Best editorial polish of all whisperx outputs. Proper nouns corrected ("Decentralized Dance Party", "Nethermind"), profanity retained where spoken ("fucked up", "motherfuckers"), natural sentence flow
+- **Completeness:** Full transcript end-to-end, from opening through "Bye"
+- **Notable:** Cleanest prose with proper capitalization, punctuation, and formatting. "Kismet" correctly transcribed where other outputs show "kids met"
+
+#### whisperx_gemini (14,060 words, 290 lines)
+
+- **Tier: 1 (Complete, Excellent)**
+- **Timestamps:** Removed entirely -- no timestamps present in output. All entries use just `**SPEAKER_XX:**` format
+- **Speaker Labels:** Maintained SPEAKER_00-03 from source
+- **Prose Quality:** Good. Uses quotation marks for direct quotes and dialogue (e.g., "Listen, man, I want you to listen to this podcast"), em dashes for parenthetical asides. More literary formatting style
+- **Completeness:** Full transcript end-to-end
+- **Notable Issue:** Complete absence of timestamps is a significant limitation for audio cross-referencing. However, the prose quality and formatting is among the most readable
+
+#### whisperx_grok (14,374 words, 294 lines)
+
+- **Tier: 1 (Complete, Excellent)**
+- **Timestamps:** Preserved `[MM:SS]` and `[H:MM:SS]` format from source
+- **Speaker Labels:** Maintained SPEAKER_00-03 + SPEAKER_06 from source
+- **Prose Quality:** Good but more raw/verbatim. Retains more filler and hesitation markers. Some passages have uncorrected lowercase text
+- **Completeness:** Full transcript end-to-end
+- **Notable Issues:** "ECC" instead of "EthCC"; "the oreo" instead of "D'Orio" (uncorrected speech-to-text error from source); "metallic" instead of "Vitalik" in one passage; "my ties" instead of "mai tais". Most faithful to source including its errors
+
+### 2c. WhisperX (cloud)-based Outputs
+
+#### whisperx-cloud_opus (13,349 words, 136 lines)
+
+- **Tier: 1 (Complete, Excellent)**
+- **Timestamps:** Preserved from source `[MM:SS]` and `[H:MM:SS]` format
+- **Speaker Labels:** Inherited the problematic SPEAKER_00/03/04/06 structure from the cloud source
+- **Prose Quality:** Good. Clean formatting despite the collapsed diarization from the source
+- **Completeness:** Full transcript end-to-end
+- **Notable Issue:** Only 136 lines due to inheriting the whisperx-cloud's massive multi-speaker blocks. Long wall-of-text paragraphs with multiple speakers collapsed into single entries. This is a source problem, not a processor problem
+
+#### whisperx-cloud_gemini (13,898 words, 216 lines)
+
+- **Tier: 1 (Complete, Excellent)**
+- **Timestamps:** Preserved from source
+- **Speaker Labels:** Inherited cloud source structure
+- **Prose Quality:** Good. Some improvement in line breaks compared to opus, with more frequent paragraph separations
+- **Completeness:** Full transcript end-to-end
+- **Notable Issues:** Same collapsed diarization inheritance from source; "ECC" instead of "EthCC"
+
+#### whisperx-cloud_grok (14,157 words, 132 lines)
+
+- **Tier: 1 (Complete, Excellent)**
+- **Timestamps:** Preserved from source
+- **Speaker Labels:** Inherited cloud source structure
+- **Prose Quality:** Raw/verbatim. Most faithfully preserves the massive collapsed blocks from the source without attempting editorial correction
+- **Completeness:** Full transcript end-to-end
+- **Notable Issues:** Fewest lines (132) reflecting the most faithful preservation of the source's collapsed structure; "Nevermind" instead of "Nethermind"; uncorrected lowercase passages; "Aya Miyaguchi" correctly identified in one passage
 
 ---
 
-## 5. Detailed Quality Notes
+## 3. Side-by-Side Transcriber Base Comparison
 
-### Tier 1 Outputs (Recommended)
+### Opening Passage (First 2 minutes)
 
-**AssemblyAI + Opus** -- Best overall combination. Accurate timestamps preserved, well-cleaned prose, proper name corrections (Kieren, Nethermind, etc.), natural paragraph breaks. SPEAKER_03/04 split for Texture is a minor annoyance but does not impair readability. Complete dialogue from opening greetings through closing remarks.
+**AssemblyAI:** Fine-grained turns. "Hear me? Can you hear me?" gets its own line (SPEAKER_00). "Yes, I can." gets its own line (SPEAKER_01). Each short interjection is separately attributed. 9 distinct speaker entries in the first 30 seconds.
 
-**AssemblyAI + Grok** -- Most faithful reproduction. Highest word retention. Good for archival accuracy but less editorial polish. Some uncorrected terms ("Nevermind" for "Nethermind", "FCC" for "EthCC").
+**WhisperX (local):** Moderate granularity. Opening lines are reasonably well separated. SPEAKER_03 handles Bob's dialogue, SPEAKER_01 handles Jamie. Some minor merging of adjacent short turns.
 
-**AssemblyAI + Gemini** -- Excellent readability with good editorial polish, merged Texture's split speaker labels. Critical flaw: regenerated timestamps to a 00:00 offset, losing the original timeline entirely. This makes it unsuitable as a primary reference.
+**WhisperX (cloud):** Severely collapsed. The opening "Can you hear me?" through "How are you?" is all lumped into a single SPEAKER_04 entry spanning 1:19 to 2:18. Subsequent multi-speaker dialogue about fall weather, co-hosting, and weather discussion is all collapsed into a single SPEAKER_00 block spanning 2:18 to 5:05.
 
-**WhisperX + Gemini** -- Excellent prose quality with literary formatting (em-dashes, quotation marks for dialogue). Critical flaw: stripped all timestamps. Excellent for reading but not for citation or reference.
+### Texture's Vision Story (~11-15 min mark)
 
-### Tier 4 Outputs (Unusable)
+All three transcribers capture this long monologue well, as it is primarily a single speaker (Texture) with minimal interruptions. The content is faithfully reproduced across all three sources with only minor word-level differences.
 
-**All GLM outputs** (3 files: assemblyai_glm, whisperx_glm, whisperx-cloud_glm) contain massive "chain-of-thought" reasoning preambles (150-320+ lines of internal analysis) before any transcript content. The GLM model exposed its internal reasoning process instead of producing clean output. These files are inflated to 19,491-45,813 words, with the vast majority being non-transcript content. All three should be regenerated or discarded.
+### Key Name/Term Handling
 
-**WhisperX + MiniMax** -- Severely truncated at 1,783 words (72 lines), covering only the first ~10% of the episode. Appears to have hit an output limit or context window issue.
+| Term | AssemblyAI | WhisperX (local) | WhisperX (cloud) |
+|---|---|---|---|
+| ChatGPT | "ChatGPT" | "Chad GPT" | "Chad GPT" |
+| PFP | "Pft" / "PFP" | "PFT texture" | "PFT texture" |
+| Nethermind | varies by processor | varies by processor | varies by processor |
+| D'Orio | "D'Orio" (inconsistent) | "Di Iorio" (inconsistent) | "Di Iorio" |
+| EthCC | varies by processor | varies by processor | varies by processor |
+
+### Timestamp Accuracy
+
+AssemblyAI and WhisperX (local) produce comparable timestamp positions, with timestamps falling close to the same points in the conversation. WhisperX (cloud) also has timestamps at approximately the right locations, despite its diarization problems. Timestamps are most useful from the AssemblyAI base as the granular turn boundaries provide more reference points.
 
 ---
 
-## 6. Recommendations
+## 4. Overall Rankings
 
-### Immediate Actions
-1. **Regenerate all GLM outputs** -- All three GLM files are unusable due to chain-of-thought leakage. Consider adjusting the GLM prompt or using a different model configuration.
-2. **Regenerate WhisperX + MiniMax** -- Severely truncated; needs re-processing.
-3. **Complete the consensus pipeline** -- The assemblyai_consensus intermediate exists but no final output was produced.
+### By Transcriber Base (for AI processing)
 
-### Best Candidates for Final Transcript
-1. **Primary recommendation: AssemblyAI + Opus** -- Best balance of completeness (96%), accuracy, timestamp preservation, and prose quality.
-2. **Runner-up: AssemblyAI + Grok** -- Most complete (100% retention) but less polished. Good for cross-reference.
-3. **Avoid: Gemini outputs** for primary reference due to inconsistent timestamp handling (regeneration or stripping).
+1. **AssemblyAI** -- Best diarization, most granular turns, highest word count. Recommended base for final output selection.
+2. **WhisperX (local)** -- Acceptable alternative with fewer speaker labels. Good for cross-referencing.
+3. **WhisperX (cloud)** -- Not recommended due to severely collapsed diarization. Outputs inherit the multi-speaker block problem.
 
-### Transcriber Recommendations
-1. **AssemblyAI should be the primary transcriber** for this episode type (multi-speaker conversational format). Its fine-grained diarization significantly outperforms both WhisperX variants.
-2. **WhisperX cloud should be deprioritized** -- Its diarization quality is notably worse than both WhisperX local and AssemblyAI for this episode.
-3. The SPEAKER_03/04 split in AssemblyAI (both representing Texture) could be addressed in post-processing by merging consecutive turns from either label.
+### By AI Processor
 
-### Processor Tier Summary
-- **Tier 1 (>90%, excellent):** Opus, Gemini, Grok, Kimi (WhisperX/cloud bases only)
-- **Tier 2 (70-89%, good):** Kimi (AssemblyAI base), ChatGPT (WhisperX bases)
-- **Tier 3 (<50%, limited value):** ChatGPT (AssemblyAI base), Qwen, MiniMax (cloud/assemblyai), Llama, DeepSeek, Mistral
-- **Tier 4 (unusable):** GLM (all bases), MiniMax (WhisperX local)
+1. **Opus** -- Best editorial polish, proper noun correction, natural prose flow. Slightly lower word count reflects appropriate removal of filler. Best for readability.
+2. **Gemini** -- Good quality but has format issues (timestamp removal in whisperx output, timestamp renumbering in assemblyai output). Literary formatting with quotation marks is a nice touch.
+3. **Grok** -- Most faithful/verbatim preservation. Highest word counts. Good for archival completeness but retains more errors and lacks editorial refinement. Some proper noun errors ("Nevermind", "FCC").
+
+### Recommended Final Outputs
+
+| Priority | Output | Rationale |
+|---|---|---|
+| **Primary** | `assemblyai_opus` | Best combination of source diarization + editorial polish. Accurate timestamps, clean prose, complete coverage. |
+| **Secondary** | `whisperx_opus` | Best WhisperX-based output. Cross-reference value with different transcriber perspective. |
+| **Archival** | `assemblyai_grok` | Most verbatim/complete. Useful as reference for any passages where editorial outputs may have over-corrected. |
+
+---
+
+## 5. Tier Summary
+
+| Output | Tier | Word Count | Notes |
+|---|---|---|---|
+| assemblyai_opus | **Tier 1** | 14,308 | Complete, excellent editorial quality |
+| assemblyai_gemini | **Tier 1** | 14,639 | Complete, good quality; timestamp renumbering issue |
+| assemblyai_grok | **Tier 1** | 14,978 | Complete, most verbatim; some proper noun errors |
+| whisperx_opus | **Tier 1** | 13,549 | Complete, excellent editorial quality |
+| whisperx_gemini | **Tier 1** | 14,060 | Complete, good quality; no timestamps |
+| whisperx_grok | **Tier 1** | 14,374 | Complete, good quality; some uncorrected errors |
+| whisperx-cloud_opus | **Tier 1** | 13,349 | Complete but collapsed diarization blocks |
+| whisperx-cloud_gemini | **Tier 1** | 13,898 | Complete but collapsed diarization blocks |
+| whisperx-cloud_grok | **Tier 1** | 14,157 | Complete but collapsed diarization blocks |
+
+All nine outputs achieve Tier 1 status (>90% of maximum word count, complete end-to-end coverage). The primary differentiators are editorial polish, timestamp handling, and inherited diarization quality rather than completeness.
+
+---
+
+*Assessment generated 2026-02-23*

--- a/outputs/episode006-christoph-jentzsch/episode006-christoph-jentzsch_quality_assessment.md
+++ b/outputs/episode006-christoph-jentzsch/episode006-christoph-jentzsch_quality_assessment.md
@@ -4,187 +4,293 @@
 
 - **Episode:** episode006-christoph-jentzsch
 - **Subject:** Christoph Jentzsch (Ethereum testing, Slock.it, The DAO)
-- **Speakers:** 5 participants (host Bob Summerwill, guest Christoph Jentzsch, Kieran James-Lubin, Jim, and one additional speaker)
+- **Speakers:** 4 participants -- host Bob Summerwill (SPEAKER_00), Kieran James-Lubin (SPEAKER_01), Christoph Jentzsch (SPEAKER_02), Jim (SPEAKER_03)
 - **Duration:** Approximately 87 minutes
-- **Transcriber sources:** 3 (WhisperX local, WhisperX Cloud, AssemblyAI)
-- **AI Processors:** 12 models across 3 transcriber bases (36 output files total, plus 3 processed variants)
-- **Assessment Date:** 2026-02-22
+- **Transcriber sources:** 3 (AssemblyAI, WhisperX local, WhisperX Cloud)
+- **AI Processors assessed:** Opus, Gemini, Grok (across all 3 transcriber bases = 9 outputs)
+- **Assessment Date:** 2026-02-23
 
 ---
 
-## 1. Transcriber Comparison
+## 1. Transcriber Quality Assessment
 
-| Transcriber | Word Count | Line Count | Diarization | Timestamp Granularity | Notable Issues |
+### Raw Transcriber Output Summary
+
+| Transcriber | Word Count | Diarization | Speaker Labels | Timestamp Style | Formatting |
 |---|---|---|---|---|---|
-| WhisperX (local) | 15,038 | 302 | 5 speakers (SPEAKER_00 through SPEAKER_04) + 1 UNKNOWN | Per-turn, ~148 timestamps | Good diarization with distinct speaker separation; lowercase for some speakers; occasional "UNKNOWN" label |
-| WhisperX Cloud | 14,932 | 158 | 9 speaker labels (SPEAKER_01, 02, 03, 04, 08) | Per-turn, ~79 timestamps | Poor diarization: multiple speakers merged into single blocks; SPEAKER_08 absorbs multiple speakers; significantly fewer turn boundaries |
-| AssemblyAI | 15,320 | 360 | 4 speakers (SPEAKER_00 through SPEAKER_03) | Per-turn, ~180 timestamps | Best diarization with cleanest speaker separation; most timestamps; consistent formatting with capitalized text |
-| AssemblyAI Consensus | 15,739 | 360 | Same as AssemblyAI but with filler words preserved | Per-turn, ~180 timestamps | Retains "uh", "um" fillers; used as enhanced base for processing |
+| AssemblyAI | 15,320 | 4 speakers (SPEAKER_00-03) | Consistent, correct separation | [MM:SS] per turn | Capitalized, clean |
+| WhisperX (local) | 15,038 | 5 speakers (SPEAKER_00-04) + 1 UNKNOWN | Generally good, minor splits | [MM:SS] per turn | Mixed case for some speakers |
+| WhisperX Cloud | 14,932 | 5 labels (01, 02, 03, 04, 08) | Poor -- speakers merged into long blocks | [MM:SS] per turn | Lowercase for host's lines |
 
-### Transcriber Quality Ranking
+### Detailed Transcriber Notes
 
-1. **AssemblyAI** -- Best overall. Cleanest diarization with 4 properly separated speakers, most timestamp granularity (180 turns), and proper capitalization. Correctly separates Rob (SPEAKER_00), Kieran (SPEAKER_01), Christoph (SPEAKER_02), and Jim (SPEAKER_03).
+**AssemblyAI (Best)**
+- Cleanest speaker separation with 4 distinct speakers correctly identified
+- Highest turn count (~180 speaker turns) providing the best conversational granularity
+- Properly capitalized text throughout
+- Consistent formatting with clear speaker labels
+- Correctly isolates short interjections (e.g., "Indeed." as its own turn at [01:11])
+- Minor transcription errors present in raw form: "Kevin Wood" for Gavin Wood, "territory physics" for theoretical physics, "AS6" for ASICs, "italic" for Vitalik, "Stefan to all" for Stefan Tual
 
-2. **WhisperX (local)** -- Good diarization with 5 speaker labels plus 1 UNKNOWN. Has 148 timestamps, which is reasonable. Speaker separation is generally accurate, though the additional SPEAKER_03/SPEAKER_04 split compared to AssemblyAI sometimes attributes Kieran's lines differently.
+**WhisperX (local) (Good)**
+- 5 speakers plus occasional UNKNOWN label; the extra split separates Jim (SPEAKER_04) from Kieran (SPEAKER_01) differently than AssemblyAI
+- ~148 turn boundaries -- fewer than AssemblyAI but adequate
+- Same quality of raw transcription errors as WhisperX Cloud (shared Whisper base)
+- Proper per-turn separation, though some longer monologues merge adjacent speakers' brief interjections
+- Correctly identifies "Dr. Christian Reitweissner" in raw form (better than AssemblyAI's "Wrightweisner")
 
-3. **WhisperX Cloud** -- Significantly inferior. Only 79 timestamps (less than half of AssemblyAI). Major diarization issues: SPEAKER_08 absorbs the host's dialogue plus other speakers' lines into single blocks, losing critical turn-by-turn attribution. Multiple speakers often merged into one paragraph, making the transcript much harder to follow.
+**WhisperX Cloud (Inferior)**
+- Major diarization problems: SPEAKER_08 absorbs the host's lines plus other speakers' dialogue into single massive blocks
+- Only ~79 turn boundaries -- less than half of AssemblyAI
+- The first block (SPEAKER_08 at [00:03]) runs continuously for over 1 minute, merging at least 3 speakers' dialogue into one paragraph
+- Same raw transcription quality as WhisperX local but far worse structural separation
+- Makes the transcript significantly harder to follow as a conversation
 
----
+### Transcriber Ranking
 
-## 2. AI Processor Comparison -- AssemblyAI Base
-
-| Processor | Word Count | % of Max | Timestamps | Formatting | Name Corrections | Filler Removal | Tier |
-|---|---|---|---|---|---|---|---|
-| **Opus** | 14,828 | 96.8% | Preserved (MM:SS) | Excellent | Yes (Jentzsch, Gavin Wood, Joseph Lubin, ETHDEV, EVM, Whisper, Stefan Tual, Henning Diedrich) | Clean | **Tier 1** |
-| **Gemini** | 15,145 | 98.9% | Preserved | Excellent | Yes | Clean | **Tier 1** |
-| **Gemini Processed** | 14,813 | 96.7% | Removed (no timestamps) | Good, no timestamps | Yes | Clean | **Tier 2** |
-| **Grok** | 14,955 | 97.6% | Preserved | Excellent | Yes | Clean | **Tier 1** |
-| **Sonnet Processed** | 14,720 | 96.1% | Removed (no timestamps) | Good, no timestamps | Yes | Clean | **Tier 2** |
-| **Kimi** | 12,210 | 79.7% | Preserved but minimal cleanup | Poor -- retains raw errors ("italic", "Kevin Wood", "AS6", "territory physics") | Minimal | Minimal | **Tier 3** |
-| **ChatGPT** | 4,012 | 26.2% | Partial (Part 1 only) | Good formatting but incomplete | Yes (what exists) | Clean | **Tier 3** |
-| **Llama** | 6,143 | 40.1% | Missing/malformed | Poor -- wrong timestamp format | Partial | Partial | **Tier 3** |
-| **Llama Processed** | 7,826 | 51.1% | Missing/malformed (e.g., [00:00], [00:01]) | Poor -- wrong timestamps | Partial | Partial | **Tier 3** |
-| **DeepSeek** | 4,021 | 26.3% | Preserved | Good for what exists, but heavily truncated | Yes | Clean | **Tier 3** |
-| **Qwen** | 5,728 | 37.4% | Preserved | Decent | Partial | Partial | **Tier 3** |
-| **Mistral** | 5,654 | 36.9% | Preserved | Decent | Partial | Partial | **Tier 3** |
-| **MiniMax** | 1,251 | 8.2% | Truncated early | Good for what exists | Yes | Clean | **Tier 4** |
-| **GLM** | 32,679 | n/a | Chain-of-thought dump | **Unusable** -- outputs reasoning/analysis notes instead of transcript | n/a | n/a | **Tier 4** |
-
-### AssemblyAI Base Top Performers
-
-**Tier 1 (>90% retention, excellent quality):**
-- **Opus** (14,828 words): Full transcript with correct timestamps, excellent name corrections (Gavin Wood for "Kevin Wood", Jentzsch for "Jens", EVM for "Ethereum rich machine", Stefan Tual for "Stefan to all"), clean filler removal, natural prose flow. Completes through the end with the sign-off at [87:27].
-- **Gemini** (15,145 words): Slightly higher word count with very similar quality. Accurate name corrections, preserved timestamps, clean formatting. Complete to the end.
-- **Grok** (14,955 words): Comparable quality to Opus and Gemini. Complete coverage, proper corrections.
-
-**Tier 2 (mostly complete, good quality but format issues):**
-- **Gemini Processed** (14,813 words): Content is high quality but timestamps were stripped during post-processing. Speaker labels preserved.
-- **Sonnet Processed** (14,720 words): Same issue -- timestamps stripped. Content is complete and well-corrected.
-
-**Tier 3 (<80% retention or significant issues):**
-- **Kimi** (12,210 words): Retains many raw transcription errors ("italic" instead of "Vitalik", "Kevin Wood" instead of "Gavin Wood", "AS6" instead of "ASICs", "territory physics" instead of "theoretical physics"). Essentially a pass-through with minimal improvement.
-- **ChatGPT** (4,012 words): Only delivered "Part 1" with a note saying to "Ask for Part 2" -- output size limit prevented completion.
-- **DeepSeek** (4,021 words): Heavily truncated, covers roughly the first quarter of the interview.
-- **Llama/Llama Processed** (6,143/7,826 words): Wrong timestamp format (minute-only counts instead of MM:SS), incomplete coverage.
-- **Qwen** (5,728 words): Truncated mid-conversation.
-- **Mistral** (5,654 words): Truncated mid-conversation.
-
-**Tier 4 (unusable):**
-- **MiniMax** (1,251 words): Barely covers the first few minutes.
-- **GLM** (32,679 words): Does not contain a processed transcript at all. Instead contains extensive chain-of-thought analysis notes ("**1. Understand the Goal:**", "**2. Analyze the Input:**", bullet-pointed correction notes). The model output its reasoning process rather than the final transcript.
+1. **AssemblyAI** -- Best diarization, most turn boundaries, cleanest formatting
+2. **WhisperX (local)** -- Good diarization, adequate turns, minor speaker label issues
+3. **WhisperX Cloud** -- Poor diarization with merged speaker blocks, unusable without AI post-processing
 
 ---
 
-## 3. AI Processor Comparison -- WhisperX (local) Base
+## 2. AI Processor Assessment -- AssemblyAI Base
 
-| Processor | Word Count | % of Max | Tier |
+### Word Counts (Opus, Gemini, Grok only)
+
+| Processor | Word Count | % of Raw (15,320) | Lines |
 |---|---|---|---|
-| **Opus** | 14,641 | 97.4% | **Tier 1** |
-| **Gemini** | 14,784 | 98.3% | **Tier 1** |
-| **Grok** | 14,816 | 98.5% | **Tier 1** |
-| **ChatGPT** | 11,861 | 78.9% | **Tier 2** |
-| **Kimi** | 12,209 | 81.2% | **Tier 2** |
-| **Llama** | 6,149 | 40.9% | **Tier 3** |
-| **MiniMax** | 5,915 | 39.4% | **Tier 3** |
-| **Mistral** | 5,561 | 37.0% | **Tier 3** |
-| **Qwen** | 5,657 | 37.6% | **Tier 3** |
-| **DeepSeek** | 4,718 | 31.4% | **Tier 3** |
-| **GLM** | 46,212 | n/a | **Tier 4** (chain-of-thought dump) |
+| Gemini | 15,145 | 98.9% | 356 |
+| Grok | 14,955 | 97.6% | 358 |
+| Opus | 14,828 | 96.8% | 354 |
 
-### Notes on WhisperX Base
-- Opus, Gemini, and Grok again lead. WhisperX Opus output is complete to the end at [81:00] with proper name corrections and clean formatting.
-- ChatGPT performed better here (11,861 words vs 4,012 on AssemblyAI), reaching about 79% retention.
-- The GLM failure is even worse here at 46,212 words of reasoning notes, the largest file in the entire output set.
+### AssemblyAI + Opus (Tier 1)
+
+**Completeness:** Complete from [00:03] to [87:28]. Final line is Christoph's sign-off "You too. That's great talking to you. Bye." All major topics covered including the DAO hack, DEVCON memories, Tokenize.it, and personal reflections.
+
+**Name Corrections (Excellent):**
+- "Kevin Wood" -> "Gavin Wood"
+- "Jentzsch" correctly throughout (raw had "Jens"/"yance")
+- "ETHDEV" (from "fdev"/"EFDEV")
+- "Ethereum Virtual Machine" (from "Ethereum rich machine")
+- "Stefan Tual" (from "Stefan to all"/"Toual")
+- "Henning Diedrich" (from fragmented "did Lexus from IBM")
+- "Joseph Lubin" (from "Joseph Rubin" in some instances)
+- "Tokenize.it" properly formatted
+- "Slock.it" properly formatted
+- "AlethZero", "AlethOne" properly formatted
+- "ASICs" (from "AS6")
+- "theoretical physics" (from "territory physics")
+- "Whisper" (from "Risper")
+- "pyEthereum" properly styled
+- "Deja Vu" (audit company name preserved)
+
+**Formatting:** Clean, readable prose. Speaker labels with timestamps preserved in `**[MM:SS] SPEAKER_XX:**` format. Filler words ("uh", "um") cleanly removed. Natural sentence flow maintained. Short interjections preserved as separate turns.
+
+**Notable Quality:** Correctly interprets "bold vision" (from raw "proud vision"), properly capitalizes DEVCON, correctly parses the Geth vs C++ audit story with clarity. The DAO discussion is complete and accurate. Properly handles the audio interruption sequence around [67:27]-[68:47].
+
+**Tier: 1 -- Complete, excellent quality**
+
+### AssemblyAI + Gemini (Tier 1)
+
+**Completeness:** Complete from [00:00] to [01:15:37]. Uses HH:MM:SS timestamp format for later sections. Final line matches Opus. Highest word count of the three (15,145).
+
+**Name Corrections:** Comparable to Opus. Uses "Devcon" capitalization style (mixed case) rather than "DEVCON". "Henning Diedrich" correctly identified. All major name corrections applied.
+
+**Formatting:** Very clean. Slightly different timestamp offset at the start ([00:00] vs [00:03]). Speaker turns are well-separated. Later timestamps switch to HH:MM:SS format (e.g., [01:00:36]) which is actually more precise for a long recording. One oddity: timestamps compress differently from Opus, suggesting Gemini may adjust timing slightly.
+
+**Notable Differences from Opus:** Gemini says "Devcon" (mixed case) while Opus says "DEVCON". Gemini retains slightly more of the conversational texture (marginally higher word count). Both are equally faithful to the source.
+
+**Tier: 1 -- Complete, excellent quality**
+
+### AssemblyAI + Grok (Tier 1)
+
+**Completeness:** Complete from [00:03] to [1:27:28]. Uses H:MM:SS format for timestamps exceeding one hour. Final line: "You too. That's great talking to you bye."
+
+**Name Corrections:** Comparable to Opus and Gemini. Correctly identifies "Henning Diedrich from IBM". "EthDev" used (mixed case). All major corrections applied.
+
+**Formatting:** Clean and readable. Preserves the same speaker turn structure. One minor issue: "decent currency" retained at [01:24] where Opus correctly renders "decentralized currency" -- this suggests Grok occasionally defers more to the raw transcription than Opus does.
+
+**Notable Differences:** Grok uses "Devcon" (mixed case) like Gemini. Grok retains some slightly more raw phrasings: "passed my PhD" (raw error) retained in one spot where Opus corrects to "paused my PhD". Minor but illustrates Opus's slightly more aggressive correction policy.
+
+**Tier: 1 -- Complete, excellent quality**
 
 ---
 
-## 4. AI Processor Comparison -- WhisperX Cloud Base
+## 3. AI Processor Assessment -- WhisperX (local) Base
 
-| Processor | Word Count | % of Max | Tier |
+### Word Counts
+
+| Processor | Word Count | % of Raw (15,038) | Lines |
 |---|---|---|---|
-| **Opus** | 14,772 | 98.6% | **Tier 1** |
-| **Gemini** | 14,927 | 99.7% | **Tier 1** |
-| **Grok** | 14,782 | 98.7% | **Tier 1** |
-| **GLM** | 16,981 | n/a | **Tier 1** (but needs verification -- may contain reasoning) |
-| **Kimi** | 12,699 | 84.8% | **Tier 2** |
-| **Llama** | 6,608 | 44.1% | **Tier 3** |
-| **Mistral** | 5,814 | 38.8% | **Tier 3** |
-| **Qwen** | 6,056 | 40.4% | **Tier 3** |
-| **ChatGPT** | 5,297 | 35.4% | **Tier 3** |
-| **MiniMax** | 5,129 | 34.2% | **Tier 3** |
-| **DeepSeek** | 1,882 | 12.6% | **Tier 4** |
+| Grok | 14,816 | 98.5% | 294 |
+| Gemini | 14,784 | 98.3% | 284 |
+| Opus | 14,641 | 97.4% | 334 |
 
-### Notes on WhisperX Cloud Base
-- The WhisperX Cloud base presents the extra challenge of merged speaker blocks. Opus successfully re-separates speakers and adds proper turn boundaries (171 timestamps from 79 input timestamps), demonstrating strong speaker identification capability.
-- DeepSeek on this base is especially poor at 1,882 words (12.6%), essentially a preamble with instructions followed by a partial transcript.
-- The WhisperX Cloud deepseek output notably begins with "Based on the guidelines, I'll clean up and format the transcript..." -- meta-commentary that should not appear in the output.
+### WhisperX + Opus (Tier 1)
+
+**Completeness:** Complete from [00:00] to [81:04]. Covers entire conversation through the final sign-off. Different total duration than AssemblyAI base (81 min vs 87 min) due to WhisperX's different timestamp calibration.
+
+**Name Corrections:** Excellent. Same quality as AssemblyAI+Opus. Correctly handles "Roman Mandeleil" (WhisperX raw had this more clearly), "Stephan Tual", "Kreuzberg", "DevCon Zero". "Corpus Ventures" rendered (from raw "Kopos"/"Kapos" variants). "GasHawk" properly identified. "cypherpunk" correctly rendered.
+
+**Speaker Handling:** WhisperX local uses SPEAKER_00 for Christoph, SPEAKER_01 for Kieran, SPEAKER_02 for Bob, SPEAKER_03 for Bob/misc, SPEAKER_04 for Jim. Opus preserves these labels faithfully. The different speaker numbering from AssemblyAI means a different mapping is needed for name replacement.
+
+**Formatting:** Clean, well-structured. 334 lines with good turn granularity. Properly handles the mid-conversation audio issues with appropriate short turns.
+
+**Tier: 1 -- Complete, excellent quality**
+
+### WhisperX + Gemini (Tier 1)
+
+**Completeness:** Complete. 14,784 words, 284 lines. Covers full conversation.
+
+**Quality:** Comparable to Opus on this base. Same name corrections applied. Slightly fewer lines (284 vs 334) suggesting some turn merging.
+
+**Tier: 1 -- Complete, excellent quality**
+
+### WhisperX + Grok (Tier 1)
+
+**Completeness:** Complete. 14,816 words, 294 lines. Highest word count on this base.
+
+**Quality:** Comparable to the other two. All major corrections applied. "chryench" retained for Twitter handle (same raw rendering issue across all processors).
+
+**Tier: 1 -- Complete, excellent quality**
 
 ---
 
-## 5. Consensus Pipeline Status
+## 4. AI Processor Assessment -- WhisperX Cloud Base
 
-- **Consensus intermediate exists:** Yes (`episode006-christoph-jentzsch_assemblyai_consensus.md`, 15,739 words)
-- **Consensus word-level JSON exists:** Yes (`episode006-christoph-jentzsch_assemblyai_consensus_words.json`)
-- **Final merged output exists:** No (`*_final.md` not found)
+### Word Counts
 
-The consensus pipeline has produced an intermediate that combines AssemblyAI base with additional word-level timing data. This consensus version retains all filler words ("uh", "um") and has the highest word count of any intermediate (15,739). However, no final merged/processed output has been produced from this consensus base.
+| Processor | Word Count | % of Raw (14,932) | Lines |
+|---|---|---|---|
+| Gemini | 14,927 | 99.97% | 196 |
+| Grok | 14,782 | 99.0% | 158 |
+| Opus | 14,772 | 98.9% | 340 |
+
+### WhisperX Cloud + Opus (Tier 1)
+
+**Completeness:** Complete from first line to [01:27:32] sign-off. 340 lines, 14,772 words.
+
+**Speaker Re-separation:** This is where Opus shines. Despite the WhisperX Cloud input having severely merged speaker blocks (SPEAKER_08 absorbing multiple speakers, only 79 turn boundaries), Opus successfully re-separates speakers and increases the turn count to 340 lines -- more granular than the raw input. It correctly attributes dialogue to different speakers even within merged blocks.
+
+**Name Corrections:** Same excellent quality. "Jeff Karras" appears in the final section (likely "Griff Green" misheard) -- this is a raw transcription error that Opus did not catch, representing a rare miss. "the diamonds and me" retained where the speaker said "Simon and me" -- another raw error not caught.
+
+**Formatting:** Well-structured despite the poor input quality. The speaker re-separation is the standout feature.
+
+**Tier: 1 -- Complete, excellent quality (with notable speaker re-separation capability)**
+
+### WhisperX Cloud + Gemini (Tier 1)
+
+**Completeness:** Complete. 14,927 words (highest on this base, nearly matching raw word count). Only 196 lines, meaning longer individual turns.
+
+**Quality:** Good corrections. Fewer turn boundaries than Opus output (196 vs 340), meaning Gemini did less speaker re-separation from the merged blocks.
+
+**Tier: 1 -- Complete, excellent quality**
+
+### WhisperX Cloud + Grok (Tier 1)
+
+**Completeness:** Complete. 14,782 words, 158 lines (fewest on this base).
+
+**Quality:** Good corrections. 158 lines closely mirrors the raw input's turn count (also around 158), indicating Grok preserved the merged structure rather than re-separating speakers. This means the diarization issues of WhisperX Cloud persist in the output.
+
+**Tier: 1 -- Complete, excellent quality (but diarization not improved)**
 
 ---
 
-## 6. Cross-Transcriber Comparison
+## 5. Cross-Transcriber Comparison
 
-### Consistent Performers Across All Three Bases
+### Consistency Table
 
-| Processor | AssemblyAI | WhisperX | WhisperX Cloud | Average | Consistency |
+| Processor | AssemblyAI (words) | WhisperX (words) | WhisperX Cloud (words) | Average | Spread |
 |---|---|---|---|---|---|
-| **Opus** | 14,828 (Tier 1) | 14,641 (Tier 1) | 14,772 (Tier 1) | 14,747 | Excellent |
-| **Gemini** | 15,145 (Tier 1) | 14,784 (Tier 1) | 14,927 (Tier 1) | 14,952 | Excellent |
-| **Grok** | 14,955 (Tier 1) | 14,816 (Tier 1) | 14,782 (Tier 1) | 14,851 | Excellent |
-| **Kimi** | 12,210 (Tier 3) | 12,209 (Tier 2) | 12,699 (Tier 2) | 12,373 | Good |
-| **GLM** | 32,679 (Tier 4) | 46,212 (Tier 4) | 16,981 (Tier 1?) | varies | Poor |
+| **Opus** | 14,828 | 14,641 | 14,772 | 14,747 | 187 (1.3%) |
+| **Gemini** | 15,145 | 14,784 | 14,927 | 14,952 | 361 (2.4%) |
+| **Grok** | 14,955 | 14,816 | 14,782 | 14,851 | 173 (1.2%) |
 
 ### Key Observations
 
-1. **Opus, Gemini, and Grok are uniformly excellent** across all three transcriber bases, consistently producing 96-100% retention with proper formatting, name corrections, and complete coverage.
+1. **All three processors are Tier 1 across all three bases.** Opus, Gemini, and Grok each produce complete, well-corrected transcripts regardless of the transcriber source. This is the ideal outcome for pipeline reliability.
 
-2. **Opus provides the best name correction quality.** Verified corrections include: "Christoph Jentzsch" (from "Jens"/"yance"), "Gavin Wood" (from "Kevin Wood"), "Ethereum Virtual Machine" (from "Ethereum rich machine"), "Stefan Tual" (from "Stefan to all"/"Toual"), "Henning Diedrich", "Joseph Lubin" (from "Joseph Rubin"), "ETHDEV" (from "fdev"/"EFDEV"), "Tokenize.it", "Slock.it", "AlethZero", "Incubed", "Kreuzberg", "Whisper" (from "Risper"), "ASICs" (from "AS6"), "theoretical physics" (from "territory physics").
+2. **Grok has the tightest word count spread** (173 words / 1.2% across bases), suggesting it is the most consistent in its processing behavior regardless of input format.
 
-3. **The processed variants (gemini_processed, sonnet_processed, llama_processed) strip timestamps**, which reduces their value for a transcript archive that depends on time references for verification and navigation.
+3. **Gemini consistently produces the highest word count** on each base, retaining more of the original conversational texture (filler-adjacent words, short transitional phrases). This is neither better nor worse -- it depends on whether maximum retention or maximum cleaning is preferred.
 
-4. **ChatGPT has inconsistent output-size behavior.** On AssemblyAI base it truncated at Part 1 (4,012 words) but on WhisperX local it reached 11,861 words. This suggests sensitivity to input formatting or context window issues.
+4. **Opus excels at speaker re-separation.** On the WhisperX Cloud base (which has severely merged speaker blocks), Opus expanded 79 input turn boundaries to 340 output lines -- a 4.3x increase. Gemini expanded to 196 (2.5x) and Grok stayed at 158 (2.0x, essentially no improvement). This demonstrates Opus's unique ability to reconstruct conversational structure from degraded input.
 
-5. **GLM consistently fails** by outputting chain-of-thought reasoning instead of the processed transcript on both AssemblyAI and WhisperX local bases. On WhisperX Cloud it may have succeeded (16,981 words at reasonable range), but this needs manual verification.
+5. **Name correction quality is equivalent** across all three processors. All correctly handle the major corrections (Gavin Wood, Jentzsch, Stefan Tual, ETHDEV/EthDev, EVM, AlethZero, Tokenize.it, Slock.it). Minor differences exist in capitalization style (DEVCON vs Devcon) and occasional edge cases.
 
-6. **Multiple models fail on long-form content:** DeepSeek, Mistral, Qwen, MiniMax, and Llama consistently produce truncated outputs (25-45% of expected length) across all bases. These models appear to hit output token limits.
+6. **Timestamp format varies by processor:**
+   - Opus: [MM:SS] throughout
+   - Gemini: [MM:SS] then [HH:MM:SS] after 1 hour
+   - Grok: [MM:SS] then [H:MM:SS] after 1 hour
+
+---
+
+## 6. Specific Quality Comparisons
+
+### Side-by-Side: Opening Lines
+
+**AssemblyAI + Opus:**
+> **[00:03] SPEAKER_00:** Okay, recording is in progress. It says so. Hello everybody. Today, delighted to have Christoph Jentzsch with us.
+
+**WhisperX + Opus:**
+> **[00:00] SPEAKER_02:** Okay, recording is in progress, it says. So hello everybody. Today delighted to have Christoph Jentzsch with us.
+
+**WhisperX Cloud + Opus:**
+> [Properly separated from merged block, same content quality]
+
+All three produce clean, readable openings with minor variation in timestamp start and phrasing.
+
+### Side-by-Side: Critical Passage (Why Geth Won)
+
+All three processors handle this complex narrative passage equivalently well. The Geth vs C++ audit story is rendered clearly with proper nouns correctly identified (Deja Vu, Ming, Polkadot, EthCore). No meaningful quality difference between Opus, Gemini, and Grok on this passage.
+
+### Side-by-Side: Emotional Passage (DEVCON 2 Reception)
+
+All three processors faithfully preserve the emotional quality of Christoph's account of receiving standing ovations at DEVCON 2 after the DAO hack. The passage about "I kind of almost destroyed Ethereum" and the community's forgiving response is rendered cleanly in all outputs. Opus uses "the hack" consistently; Grok uses "the fork" in one instance (WhisperX Cloud base) which may reflect a raw transcription difference.
 
 ---
 
 ## 7. Recommendations
 
-### Immediate Actions
+### Primary Transcript Selection
 
-1. **Select AssemblyAI + Opus as the primary transcript** for this episode. It has the best combination of diarization quality (AssemblyAI), name corrections, complete coverage, and preserved timestamps.
+1. **Recommended: AssemblyAI + Opus** as the primary transcript. It offers the best combination of:
+   - AssemblyAI's superior diarization (4 clean speakers, 180 turn boundaries)
+   - Opus's excellent name corrections (most aggressive and accurate)
+   - Opus's speaker re-separation capability (insurance against diarization issues)
+   - Complete coverage (96.8% word retention, full conversation end-to-end)
+   - Clean [MM:SS] timestamp format throughout
 
-2. **AssemblyAI + Gemini is an equally strong alternative** with marginally higher word retention (15,145 vs 14,828), useful as a cross-reference.
+2. **Strong alternative: AssemblyAI + Gemini** with marginally higher word retention (98.9%) for cross-reference.
 
-3. **Delete or archive GLM outputs** from all three bases. The AssemblyAI and WhisperX local GLM outputs are chain-of-thought dumps with no usable transcript content. The WhisperX Cloud GLM output should be manually verified.
-
-4. **Delete or archive ChatGPT AssemblyAI output** as it is a truncated Part 1 with explicit instructions to "ask for Part 2."
-
-### Pipeline Improvements
-
-5. **Complete the consensus pipeline** by processing the `assemblyai_consensus.md` intermediate through Opus to produce a final output.
-
-6. **Add output validation** to detect chain-of-thought dumps (e.g., check if output begins with common reasoning markers like "**Task Analysis:**", "**1. Understand the Goal:**", or "**Step 1:**") and flag them automatically.
-
-7. **Add output length validation** to flag any processor output below 60% of the input word count as likely truncated.
-
-8. **Consider dropping underperforming models** from the pipeline for long-form content: MiniMax, DeepSeek, Llama, Mistral, and Qwen consistently fail to produce complete transcripts. Running them wastes compute resources.
-
-9. **For processed variants** (gemini_processed, sonnet_processed, llama_processed), ensure timestamps are preserved during post-processing. The timestamp stripping significantly reduces the archival value of these outputs.
+3. **Validation reference: AssemblyAI + Grok** as a third independent check.
 
 ### Quality Notes
 
-10. **Speaker identification caveat:** None of the outputs replace SPEAKER_XX labels with actual names. For a final published transcript, a post-processing step to map SPEAKER_00 -> Bob Summerwill, SPEAKER_01 -> Kieran James-Lubin, SPEAKER_02 -> Christoph Jentzsch, SPEAKER_03 -> Jim would significantly improve readability.
+4. **Speaker label mapping needed for final publication:**
+   - AssemblyAI: SPEAKER_00 = Bob Summerwill, SPEAKER_01 = Kieran James-Lubin, SPEAKER_02 = Christoph Jentzsch, SPEAKER_03 = Jim
+   - WhisperX local: SPEAKER_00 = Christoph, SPEAKER_01 = Kieran, SPEAKER_02 = Bob, SPEAKER_03 = Bob/misc, SPEAKER_04 = Jim
 
-11. **WhisperX Cloud is not recommended** as a primary base for this episode due to its poor diarization (merged speaker blocks, only 79 turn boundaries vs 180 for AssemblyAI).
+5. **Uncaught raw errors to manually fix in final version:**
+   - "Jeff Karras" -> likely "Griff Green" (WhisperX Cloud base)
+   - "the diamonds and me" -> "Simon and me" (WhisperX Cloud base)
+   - "chryench" / "ChrYench" -> "@ChrJentzsch" (Twitter handle, all bases)
+   - "Kopos" / "Kapos" / "Corpus" Ventures -> verify correct name
+   - "decent currency" vs "decentralized currency" at ~[01:24] (varies by base/processor)
+
+6. **WhisperX Cloud base is not recommended** as a primary source for this episode due to its severely degraded diarization. However, Opus's re-separation of this base demonstrates robustness.
+
+### Tier Summary
+
+| Output | Tier | Notes |
+|---|---|---|
+| AssemblyAI + Opus | **Tier 1** | Recommended primary |
+| AssemblyAI + Gemini | **Tier 1** | Strong alternative, highest word count |
+| AssemblyAI + Grok | **Tier 1** | Consistent, reliable |
+| WhisperX + Opus | **Tier 1** | Good alternative base |
+| WhisperX + Gemini | **Tier 1** | Complete |
+| WhisperX + Grok | **Tier 1** | Complete |
+| WhisperX Cloud + Opus | **Tier 1** | Notable speaker re-separation |
+| WhisperX Cloud + Gemini | **Tier 1** | Complete but merged turns |
+| WhisperX Cloud + Grok | **Tier 1** | Complete but merged turns |

--- a/outputs/episode007-jacob-czepluch/episode007-jacob-czepluch_quality_assessment.md
+++ b/outputs/episode007-jacob-czepluch/episode007-jacob-czepluch_quality_assessment.md
@@ -1,197 +1,275 @@
 # Episode 007 (Jacob Czepluch) -- Quality Assessment Report
 
+**Assessment date:** 2026-02-23
+**Assessor:** Claude Opus 4.6 (self-assessment)
+
 ## Overview
 
 - **Episode:** 007 -- Jacob Czepluch
 - **Subject:** Jakob Czepluch discusses his internship at ETHDEV Berlin (Aug--Dec 2015), working on the Python client, the Ethereum Foundation funding crisis, and his experiences at DevCon 1.
-- **Duration:** ~16 minutes
-- **Transcriber bases:** AssemblyAI, WhisperX (local), WhisperX-Cloud
-- **AI Processors:** 11 models (opus, chatgpt, gemini, llama, deepseek, grok, kimi, glm, minimax, mistral, qwen)
-- **Consensus pipeline:** Present (assemblyai consensus, whisperx-cloud consensus, whisperx consensus, intermediate consensus, final)
+- **Duration:** ~16 minutes (00:01 to 15:52)
+- **Transcriber bases:** AssemblyAI, WhisperX-Cloud, WhisperX (local)
+- **AI Processors assessed:** Opus, Gemini, Grok (per instructions)
 
 ---
 
-## 1. Transcriber Comparison
+## 1. Transcriber Quality
 
-| Transcriber | Diarization | Timestamp Granularity | Capitalization/Punctuation | Content Quality | Usability |
-|---|---|---|---|---|---|
-| **AssemblyAI** | Excellent (2 speakers, correctly assigned) | Fine-grained (~110 timestamps) | Full punctuation and capitalization | High fidelity to spoken content | **Best** |
-| **WhisperX-Cloud** | Adequate (2 speakers, some mixing within long blocks) | Very coarse (~6 timestamps) | Mixed (some capitalized, some lowercase) | Good content capture, minimal artifacts | **Usable** |
-| **WhisperX (local)** | Broken (2 speakers detected but content is hallucinated) | 6 timestamps | N/A | **CORRUPTED** -- entirely "Thank you" hallucinations | **Unusable** |
+### AssemblyAI (Raw Base)
+- **Words:** 2,924
+- **Lines:** ~100 (well-segmented speaker turns)
+- **Diarization:** Excellent -- 2 speakers correctly identified, ~110 fine-grained speaker turns
+- **Punctuation/Capitalization:** Full punctuation and proper capitalization throughout
+- **Content fidelity:** High -- captures the full conversation faithfully
+- **Known ASR errors:** "Dark Prague" (should be ETHPrague), "FDEV" (should be ETHDEV), "Florian Glutz" (should be Florian Glatz), "DEFCON" (should be DevCon), "Fabian Fogel Stella" (should be Fabian Vogelsteller), "Bob Samuel" (should be Bob Summerwill), "Some Python Simonson" (should be Gustav Simonsson)
+- **Verdict:** Best transcriber base by a wide margin. Clean structure, correct speaker assignment, minor phonetic ASR errors that AI processors easily correct.
 
-### Transcriber Notes
+### WhisperX-Cloud (Raw Base)
+- **Words:** 3,005
+- **Lines:** 35 (only ~6 speaker turns -- extremely coarse)
+- **Diarization:** Poor -- only 6 massive blocks, each spanning 2-5 minutes. Both speakers are mixed together within single blocks. Speaker labels (SPEAKER_00 and SPEAKER_01) are swapped relative to AssemblyAI.
+- **Punctuation/Capitalization:** All lowercase, no punctuation
+- **Content fidelity:** Good -- captures the full conversation content accurately
+- **Known ASR errors:** Similar phonetic issues plus "thorian" (for Florian), "minute launched" (for mainnet launched), "limestream" (for livestream), "fabian focus" (for Fabian Vogelsteller), "utah" (for Jutta)
+- **Verdict:** Usable for content but the coarse segmentation and speaker mixing make it a significantly harder base for AI processors to work with.
 
-- **AssemblyAI** is the clear winner: clean diarization with ~110 individual speaker turns, proper punctuation and capitalization, and high-fidelity content. Minor issues include "Dark Prague" instead of "DevCon Prague" or "ETHPrague", "FDEV" instead of "ETHDEV", "Florian Glutz" instead of "Florian Glatz", and "DEFCON" instead of "DevCon" -- but these are phonetic transcription issues easily corrected by AI processors.
-- **WhisperX-Cloud** provides the full conversation content but bundles everything into only 6 massive blocks, making diarization effectively unusable at the turn level. It mixes both speakers within single blocks. The content itself is largely accurate but includes lowercase sections and inconsistent formatting.
-- **WhisperX (local)** is completely corrupted. The entire output consists of "Thank you" repeated across 6 blocks with no actual conversation content. This is a known failure mode of WhisperX with certain audio inputs.
-
----
-
-## 2. AI Processor Comparison -- AssemblyAI Base
-
-All 11 AI processors were run against the AssemblyAI transcription. The AssemblyAI base had ~2,745 baseline words and ~110 timestamps.
-
-| Processor | Lines | Timestamps | Speaker Labels | Proper Nouns | Prose Quality | Formatting | Tier |
-|---|---|---|---|---|---|---|---|
-| **Opus** | 225 | 110 (all preserved) | Correct | Excellent (Summerwill, ETHDEV, Vogelsteller, DevCon, Glatz, Jentzsch) | Excellent -- faithful, natural flow | Standard format, clean | **Tier 1** |
-| **ChatGPT** | 217 | 106 | Correct | Very Good (Summerwill, Vogelsteller, Jentzsch, van de Sande) but "EFDEV", "Gavin" not "Gav" | Excellent -- good punctuation, em-dashes, natural | Clean, uses dashes stylistically | **Tier 1** |
-| **Gemini** | 217 | 108 | Correct | Very Good (Summerwill, Vogelsteller, Gustav Simonsson, HydraChain, AlethZero) | Excellent -- clean prose | Clean | **Tier 1** |
-| **Grok** | 225 | 110 | Correct | Very Good (Summerwill, Vogelsteller, Jentzsch, Ethcore) | Excellent -- close to source | Clean | **Tier 1** |
-| **DeepSeek** | 224 | 110 | Correct | Adequate ("Florian Glutz", "FDEV", "Dark Prague" -- retains ASR errors) | Good -- faithful but less corrected | Clean | **Tier 2** |
-| **Kimi** | 224 | 110 | Correct | Adequate ("Florian Glutz", "FDEV", "Defcon" -- retains ASR errors) | Good -- faithful transcription | Clean | **Tier 2** |
-| **GLM** | 224 | 110 | Correct | Adequate ("Florian Glutz", "FDEV", "Fabian Vogelstella") | Good -- some minor ASR artifacts retained | Clean | **Tier 2** |
-| **Llama** | 187 | 94 | Correct | Adequate ("Dark Prague", "Florian Glutz", "FDEV", "Devcon" mix) | Good -- some merging of speaker turns | Clean, slightly condensed | **Tier 2** |
-| **MiniMax** | 222 | 111 | Correct | Adequate ("Florian Glutz", "FDEV") | Good -- close to source text | Clean | **Tier 2** |
-| **Qwen** | 200 | ~100 | Correct | Good ("Summerwill", "C++", "Gavin Wood" -- corrects well) | Good but some turns merged | Clean | **Tier 2** |
-| **Mistral** | 71 | ~8 | **Broken** (loses speaker attribution mid-transcript) | Good names when present | **Major formatting failure** -- collapses many turns into single speaker blocks, loses diarization after first few minutes | **Tier 3** |
-
-### Key Observations -- AssemblyAI Base
-
-1. **Opus** delivers the best overall result: full timestamp preservation, excellent proper noun correction ("Bob Summerwill", "ETHDEV", "DevCon", "Florian Glatz", "Fabian Vogelsteller", "Christoph Jentzsch"), natural prose flow, and no content loss.
-2. **ChatGPT** and **Gemini** are close runner-ups with excellent prose quality and strong proper noun handling. ChatGPT uses em-dashes stylistically. Gemini correctly identifies "Gustav Simonsson" and "AlethZero".
-3. **Grok** is nearly identical to Opus in fidelity but retains slightly more ASR artifacts.
-4. **DeepSeek, Kimi, GLM, MiniMax** all produce competent, complete transcripts but are less aggressive about correcting ASR errors (retaining "Florian Glutz", "FDEV", "Dark Prague").
-5. **Llama** merges some short speaker turns, reducing the number of timestamp blocks from 110 to 94, but content is complete.
-6. **Mistral** has a severe formatting deficiency: it collapses the diarized transcript into long undifferentiated blocks, losing speaker attribution for large sections. Content is present but the conversational structure is destroyed.
+### WhisperX Local (Raw Base)
+- **Words:** 93
+- **Lines:** 12
+- **Diarization:** 2 speakers detected, 6 timestamp blocks
+- **Content:** **COMPLETELY CORRUPTED** -- the entire output consists of "Thank you" repeated dozens of times across all blocks. Zero actual conversation content was captured. This is a catastrophic hallucination failure.
+- **Verdict:** Entirely unusable. A total transcription failure.
 
 ---
 
-## 3. AI Processor Comparison -- WhisperX-Cloud Base
+## 2. AI Processor Quality -- Opus, Gemini, Grok (AssemblyAI Base)
 
-The WhisperX-Cloud base had only ~6 massive blocks with ~2,624 words. AI processors needed to re-segment the conversation.
+### AssemblyAI + Opus (2,868 words, 225 lines)
 
-| Processor | Diarization Recovery | Speaker Labels | Content Quality | Formatting | Tier |
-|---|---|---|---|---|---|
-| **Opus** | Strong -- creates ~95 timestamps from 6 | Correct (re-identifies speakers) | Excellent -- content preserved, names corrected | Has formatting artifacts (fmt_bad=95 per review excerpts) | **Tier 2** |
-| **Gemini** | Moderate -- creates ~58 timestamps from 6 | Correct | Very Good -- uses bold for proper nouns | Clean formatting | **Tier 1** |
-| **Other processors** | Varies | Mixed | Good to Very Good | Varies | **Tier 1--2** |
+**Completeness:** 98% of max (2,868 / 2,924 raw) -- **Tier 1**
 
-### Key Observations -- WhisperX-Cloud Base
+**First 150 lines assessment:**
+- Opens correctly with full greeting exchange
+- Speaker diarization perfectly preserved from AssemblyAI base
+- Timestamps retained at full granularity (~110 individual turns)
+- Proper noun corrections are excellent: "Bob Summerwill" (from "Bob Samuel"), "ETHDEV" (from "FDEV"), "DevCon" (from "DEFCON/Defcon"), "Florian Glatz" (from "Florian Glutz"), "Fabian Vogelsteller" (from "Fogel Stella"), "Christoph Jentzsch" (from "Christoph Jens"), "DevCon Prague" (from "Dark Prague")
+- Correctly identifies "Geth" from "the guest"
+- "C++" properly formatted throughout
+- Natural conversational flow preserved with appropriate filler word removal
 
-- The whisperx-cloud base's extremely coarse segmentation (6 blocks) makes the AI processor's job much harder. Processors must re-segment and re-assign speakers.
-- **Gemini** on whisperx-cloud stands out for excellent re-segmentation with proper bold markup on proper nouns (Florian Glatz, Felix Lange, Fabian Vogelsteller, Christoph Jentzsch, Ming Chan, EthCore, Parity, etc.).
-- **Opus** on whisperx-cloud produces a more complete output but the REVIEW_EXCERPTS document flags 95 formatting issues.
+**Last 100 lines assessment:**
+- Complete through to final exchange at [15:52]
+- HydraChain correctly identified
+- "Raiden Network" correctly spelled
+- "FreeMyVunk" correctly rendered (from "free my bunk")
+- "Aleth" rendered (close to correct "AlethZero")
+- DevCon comparisons (1, 2, 3) and Cancun reference all intact
+- Closing exchange fully preserved: "Well, thanks so much" / "Yeah, you're very welcome" / "All the very best" / "Thank you. You too."
 
----
+**Quality notes:**
+- One minor issue: retains "Python, Simonson" at [04:34] rather than correcting to "Gustav Simonsson" -- but this is a difficult correction since the ASR output "Some Python Simonson" is ambiguous
+- "Aleth" at [15:01] -- partially correct but should be "AlethZero" (or "Aleth0")
+- Overall prose reads naturally and faithfully to conversational speech
 
-## 4. AI Processor Comparison -- WhisperX (Local) Base
-
-| Processor | Output Quality | Tier |
-|---|---|---|
-| **All processors** | Corrupted input produces corrupted output. The whisperx local output contains only "Thank you" hallucinations. Even Opus produces only 6 lines of "Thank you." | **Tier 4 (Unusable)** |
-
-The whisperx (local) transcription is entirely hallucinated. No AI processor can recover meaningful content from it. All outputs from this base are unusable.
-
----
-
-## 5. Consensus Pipeline Assessment
-
-### Per-Transcriber Consensus Files
-
-| File | Status | Quality |
-|---|---|---|
-| `assemblyai_consensus.md` | Present | Good -- merges 11 processor outputs; includes filler words (uh, um) that individual processors may have cleaned |
-| `whisperx-cloud_consensus.md` | Present | Usable but retains coarse segmentation and speaker mixing from base |
-| `whisperx_consensus.md` | Present | **Unusable** -- inherits "Thank you" corruption from base |
-
-### Intermediate Consensus
-
-The `intermediate_consensus.md` (merging across transcriber bases) and `final.md` are both present but show **severe degradation**. Reading the final output reveals:
-
-- Massive repetition of content (sentences and phrases duplicated many times)
-- Fragmented speaker attribution (interleaving single words between SPEAKER_00 and SPEAKER_01)
-- Garbled word-level merging that creates incoherent text
-- Timestamp collision (many entries at the same second)
-- The corrupted whisperx base has contaminated the cross-transcriber consensus
-
-**The final.md is NOT usable as a transcript.** It is substantially worse than any individual good processor output.
-
-### Root Cause
-
-The consensus pipeline merges word-level alignment data across all three transcriber bases. Since the whisperx (local) base is entirely corrupted ("Thank you" hallucinations), and the whisperx-cloud base has only 6 coarse blocks with mixed speakers, the word-level alignment process produces garbled output when attempting to reconcile these fundamentally incompatible sources.
+**Tier: 1 (Complete, excellent quality)**
 
 ---
 
-## 6. Cross-Transcriber Comparison
+### AssemblyAI + Gemini (2,747 words, 216 lines)
 
-| Metric | AssemblyAI | WhisperX-Cloud | WhisperX (Local) |
-|---|---|---|---|
-| **Raw transcript quality** | Excellent | Adequate | Corrupted |
-| **Best single processor output** | assemblyai_opus (Tier 1) | whisperx-cloud_gemini (Tier 1) | None usable |
-| **Proper noun accuracy (best processor)** | High (Summerwill, Glatz, Vogelsteller, Jentzsch, DevCon) | High with bold markup | N/A |
-| **Speaker turn granularity** | ~110 turns | ~6 blocks | N/A |
-| **Timestamp accuracy** | Per-utterance | Per-block (~2--5 min spans) | N/A |
-| **Per-transcriber consensus** | Good | Adequate | Unusable |
+**Completeness:** 94% of max (2,747 / 2,924 raw) -- **Tier 1**
 
----
+**First 150 lines assessment:**
+- Opens correctly with greeting exchange
+- Speaker diarization preserved at full granularity
+- Timestamps match AssemblyAI base faithfully
+- Proper noun corrections are excellent: "Bob Summerwill", "ETHPrague" (the only processor to use this more accurate name for the venue), "EthDev", "DevCon", "Florian Glatz", "Fabian Vogelsteller", "Christoph Jentzsch"
+- Standout: correctly identifies "Gustav Simonsson" (from "Some Python Simonson") -- most other processors missed this
+- Correctly identifies "C" client references (though drops the "++" in some instances -- "the C client" vs "the C++ client")
+- Clean prose with good punctuation
 
-## 7. Automated Quality Scores (from ai_quality_assessment.json)
+**Last 100 lines assessment:**
+- Complete through to final exchange at [15:52]
+- "HydraChain" correctly capitalized
+- "Raiden Network" correct
+- Standout: correctly renders "AlethZero" (from "ls0"/"Aleth") -- most other processors missed this
+- "FreeMyVunk" correctly identified
+- "BlockApps" correctly identified with context question about "the Haskell project"
+- Closing exchange fully preserved
 
-The automated pipeline scored models based on input preservation, consensus alignment, length, and format:
+**Quality notes:**
+- Uses "ETHPrague" which is likely the most correct venue name -- contextually the recording was at ETHPrague, not "DevCon Prague"
+- "EthDev" rather than "ETHDEV" -- a reasonable alternative capitalization
+- Some lines slightly more condensed than Opus (merges a few very short utterances)
+- The "C" vs "C++" distinction is inconsistently handled -- sometimes says "C client" when "C++ client" would be more accurate, sometimes correct
+- The prose reads very cleanly and professionally
 
-| Rank | Model | Quality Score | Word Count |
-|---|---|---|---|
-| 1 | Llama | 0.433 | 3,564 |
-| 2 | Qwen | 0.392 | 3,198 |
-| 3 | Grok | 0.355 | 2,968 |
-| 4 | DeepSeek | 0.352 | 3,055 |
-| 5 | Opus | 0.343 | 3,071 |
-| 6 | Kimi | 0.342 | 3,241 |
-| 7 | GLM | 0.342 | 2,564 |
-| 8 | Mistral | 0.339 | 2,776 |
-| 9 | ChatGPT | 0.338 | 2,851 |
-| 10 | MiniMax | 0.337 | 3,013 |
-| 11 | Gemini | 0.333 | 2,838 |
-
-**Note:** These automated scores do NOT align well with human quality assessment for this episode. The automated scoring rewards raw word count and surface-level text similarity, which favors models that retain more filler words and ASR artifacts. In manual review, Opus, ChatGPT, and Gemini produce higher quality prose despite scoring lower on automated metrics.
+**Tier: 1 (Complete, excellent quality)**
 
 ---
 
-## 8. Recommendations
+### AssemblyAI + Grok (2,830 words, 224 lines)
 
-### Immediate Actions
+**Completeness:** 97% of max (2,830 / 2,924 raw) -- **Tier 1**
 
-1. **Best available transcript:** Use `episode007-jacob-czepluch_assemblyai_opus.md` as the definitive transcript for this episode. It has the highest overall quality: full timestamp preservation, correct speaker attribution, excellent proper noun handling, and natural conversational flow.
+**First 150 lines assessment:**
+- Opens correctly with full greeting exchange
+- Speaker diarization perfectly preserved
+- Full timestamp granularity maintained (~110 turns)
+- Proper noun corrections: "Bob Summerwill" (correct), "Devcon Prague" (reasonable), "Ethereum Foundation" (from "FDEV" -- different interpretation), "DevCon"/"Devcon" (mostly correct, inconsistent capitalization), "Florian Glatz" (correct), "Fabian Vogelsteller" (correct), "Christoph Jentzsch" (correct)
+- "Piper Merriam" at [04:34] -- this is an incorrect proper noun substitution. The ASR output "Some Python Simonson" likely refers to Gustav Simonsson, not Piper Merriam. This is a factual error introduced by the AI processor.
+- "C" client references sometimes correct ("C++"), sometimes abbreviated
 
-2. **Runner-up transcripts:** `assemblyai_chatgpt.md` and `assemblyai_gemini.md` are strong alternatives. Gemini is notable for correctly identifying "Gustav Simonsson" and "AlethZero" which other processors missed.
+**Last 100 lines assessment:**
+- Complete through to final exchange at [15:52]
+- "Hydrachain" -- lowercase 'c' inconsistency (should be "HydraChain")
+- "Raiden network" -- lowercase 'n' inconsistency
+- "free my bunk" retained without correction to "FreeMyVunk" -- missed proper noun correction
+- "LES or the Geth client" -- reasonably rendered but the reference is likely to AlethZero, not LES (Light Ethereum Subprotocol)
+- "Gavin" correctly identified throughout
+- DevCon comparison section complete
+- Closing exchange fully preserved
 
-3. **Do NOT use the final.md** -- it is severely degraded by the corrupted whisperx base contaminating the cross-transcriber consensus.
+**Quality notes:**
+- The "Piper Merriam" substitution at [04:34] is a significant factual error -- the context (someone doing Go/Python work in the Berlin office in 2015) points to Gustav Simonsson, not Piper Merriam
+- Inconsistent proper noun capitalization: "Devcon" vs "DevCon", "Hydrachain" vs "HydraChain"
+- "Ethereum Foundation" is used where the original says "FDEV" -- the correct entity name is "ETHDEV" (a separate organization from the Foundation at that time)
+- Retains "free my bunk" without correcting to "FreeMyVunk"
+- Despite these issues, the overall prose quality is good and the transcript reads naturally
 
-### Pipeline Improvements
-
-4. **Corrupted source detection:** The pipeline should detect and exclude completely corrupted transcriber outputs (like the whisperx "Thank you" hallucination) before running consensus. A simple heuristic: if >50% of words in a transcription are the same token, flag it as corrupted.
-
-5. **Whisperx (local) re-run:** Consider re-running the local WhisperX transcription with different parameters or a different model checkpoint. The current output is a total failure.
-
-6. **Mistral formatting fix:** The Mistral processor has a systematic issue where it collapses diarized conversations into monologue blocks. This should be addressed at the prompt/model level, or Mistral outputs should be flagged for this deficiency.
-
-7. **Automated scoring calibration:** The automated quality scores inversely correlate with manual quality assessment for this episode. Consider adding metrics for: proper noun accuracy, timestamp preservation ratio, and speaker turn fidelity.
-
-### Proper Noun Corrections Needed
-
-The following corrections should be applied to any transcript used as definitive:
-
-| ASR Output | Correct Form |
-|---|---|
-| Dark Prague | ETHPrague (or DevCon Prague) |
-| FDEV / EFDEV / EF DEV | ETHDEV |
-| Florian Glutz | Florian Glatz |
-| Defcon / DEFCON | DevCon |
-| Fabian Vogelstella | Fabian Vogelsteller |
-| Fabian Focus Stella | Fabian Vogelsteller |
-| Bob Samuel / Bob Simul | Bob Summerwill |
-| Some Python Simonson | Gustav Simonsson |
-| the guest team / the guest | the Geth team |
-| ls0 / LES 0 / Aleth | AlethZero |
-| Radon / Raiden | Raiden Network |
-| hydrogen / HydraChain | HydraChain |
-| F Core | Ethcore |
-| free my bunk / Free My Vunk | FreeMyVunk |
-| knosys | Gnosis |
-| Alice Van der Sande | Alex Van de Sande |
+**Tier: 1 (Complete, excellent quality -- but with notable proper noun errors)**
 
 ---
 
-## Summary
+## 3. AI Processor Quality -- Opus, Gemini, Grok (WhisperX-Cloud Base)
 
-Episode 007 has a strong best-available transcript via the AssemblyAI + Opus pipeline. The main quality issue is that the cross-transcriber consensus pipeline (final.md) is severely degraded due to the corrupted WhisperX (local) base poisoning the merge. The assemblyai-based individual processor outputs are all of good to excellent quality, with Opus, ChatGPT, and Gemini as the top three. The WhisperX-Cloud outputs are usable but limited by coarse segmentation. The WhisperX (local) outputs are entirely unusable.
+### WhisperX-Cloud + Opus (2,729 words, 80 lines)
+
+**Completeness:** 91% of max (2,729 / 3,005 raw) -- **Tier 1**
+
+**Assessment:**
+- Dramatically re-segments the 6 coarse whisperx-cloud blocks into finer-grained speaker turns
+- Speaker labels reassigned and diarization recovery is strong
+- However, the coarse input means timestamps are inherited from the 6 original blocks, so temporal resolution is much lower than the AssemblyAI variants
+- Content is well-preserved; proper noun corrections are applied
+- Formatting follows the standard pattern but the reduced line count (80 vs 225 for assemblyai_opus) reflects the coarser segmentation
+- Long monologue-style blocks where whisperx-cloud merged speakers
+
+**Tier: 1 (Complete content, but coarser segmentation than AssemblyAI base)**
+
+---
+
+### WhisperX-Cloud + Gemini (2,704 words, 116 lines)
+
+**Completeness:** 90% of max (2,704 / 3,005 raw) -- **Tier 1**
+
+**Assessment:**
+- Re-segments the 6 blocks into ~58 speaker turns -- moderate recovery
+- Speaker identification is correct
+- Uses **bold** markup on proper nouns (Florian Glatz, Felix Lange, Fabian Vogelsteller, Christoph Jentzsch, Ming Chan, EthCore, Parity, Maker, ERC-20, Raiden Network, HydraChain, BlockApps STRATO, FreeMyVunk, AlethZero, ConsenSys, Gnosis)
+- This bold markup is unique to Gemini and provides excellent visual scanning for name verification
+- "Gustav Simonsson" correctly identified even from the whisperx-cloud input
+- "AlethZero" correctly identified
+- Clean, professional prose throughout
+
+**Tier: 1 (Complete, excellent quality with standout bold markup feature)**
+
+---
+
+### WhisperX-Cloud + Grok (2,732 words, 36 lines)
+
+**Completeness:** 91% of max (2,732 / 3,005 raw) -- **Tier 1**
+
+**Assessment:**
+- Minimal re-segmentation: retains approximately the same coarse block structure as the whisperx-cloud input (only 36 lines)
+- Speaker turns are very long, with multiple exchanges bundled into single blocks
+- Content is complete but the conversational structure is poorly recovered
+- Some proper noun corrections applied but less thoroughly than Opus or Gemini on this base
+- Reading experience is significantly worse than the assemblyai_grok variant due to wall-of-text formatting
+
+**Tier: 2 (Complete content, but poor re-segmentation -- formatting issues reduce usability)**
+
+---
+
+## 4. AI Processor Quality -- WhisperX (Local) Base
+
+| Processor | Words | Status | Tier |
+|-----------|-------|--------|------|
+| **Opus** | 24 | Only "Thank you" lines -- garbage in, garbage out | **Tier 4** |
+| **Gemini** | 26 | Only "Thank you" lines with minor additions | **Tier 4** |
+| **Grok** | 93 | Retains corrupted "Thank you" repetitions | **Tier 4** |
+
+All WhisperX local processor outputs are **completely unusable**. The corrupted input ("Thank you" hallucination loops) cannot be recovered by any AI processor.
+
+---
+
+## 5. Cross-Transcriber Side-by-Side Comparison
+
+Comparing identical passages across the two usable transcriber bases:
+
+### Opening (00:01-00:15)
+
+**AssemblyAI raw:** "So, hello." / "Hello, Bob." / "So, yes, I'm Bob Samuel, recording here at Dark Prague for Early days of Ethereum. And I have here Jakob."
+
+**WhisperX-Cloud raw:** "so hello hello bob um so yes i'm bob simul uh recording here at dark prague for early days of ethereum and i have here um yakub good enough good enough yes there you go"
+
+**Analysis:** AssemblyAI provides clean sentence-level segmentation with proper punctuation. WhisperX-Cloud dumps everything into one run-on lowercase block, mixing both speakers. AssemblyAI preserves "Jakob" closer to correct; WhisperX-Cloud has "yakub". Both have the same venue error ("dark prague").
+
+### Names at [04:33-04:49]
+
+**AssemblyAI raw:** "Some Python Simonson, I think he was doing go stuff."
+
+**WhisperX-Cloud raw:** "python simonson i think he was doing ghost stuff"
+
+**Analysis:** Both capture the same difficult passage. WhisperX-Cloud has "ghost" instead of "go/Ghost" (the GHOST protocol is actually a valid Ethereum reference, making this ambiguous). Neither correctly renders "Gustav Simonsson" at the ASR level -- this requires AI correction.
+
+### Key name corrections by AI processors:
+
+| Name | Correct | Opus (AAI) | Gemini (AAI) | Grok (AAI) |
+|------|---------|------------|--------------|------------|
+| Bob Summerwill | Bob Summerwill | Correct | Correct | Correct |
+| ETHPrague | ETHPrague | "DevCon Prague" | "ETHPrague" | "Devcon Prague" |
+| ETHDEV | ETHDEV | "ETHDEV" | "EthDev" | "Ethereum Foundation" |
+| Florian Glatz | Florian Glatz | Correct | Correct | Correct |
+| Gustav Simonsson | Gustav Simonsson | "Simonson" | Correct | "Piper Merriam" (wrong) |
+| Fabian Vogelsteller | Fabian Vogelsteller | Correct | Correct | Correct |
+| Christoph Jentzsch | Christoph Jentzsch | Correct | Correct | Correct |
+| Alex Van de Sande | Alex Van de Sande | Correct | Correct | Correct |
+| AlethZero | AlethZero | "Aleth" (partial) | Correct | "LES" (different entity) |
+| FreeMyVunk | FreeMyVunk | Correct | Correct | "free my bunk" (uncorrected) |
+| HydraChain | HydraChain | Correct | Correct | "Hydrachain" (capitalization) |
+| Gnosis | Gnosis | Correct | Correct | Correct |
+
+**Winner for proper nouns:** Gemini -- correctly identifies Gustav Simonsson and AlethZero, which both Opus and Grok miss or get wrong.
+
+---
+
+## 6. Summary and Rankings
+
+### Overall Processor Rankings (AssemblyAI base, Opus/Gemini/Grok only)
+
+| Rank | Processor | Words | Tier | Strengths | Weaknesses |
+|------|-----------|-------|------|-----------|------------|
+| 1 | **Gemini** | 2,747 | **Tier 1** | Best proper noun accuracy (Gustav Simonsson, AlethZero, ETHPrague), clean prose | Slightly shorter, some C/C++ inconsistency |
+| 2 | **Opus** | 2,868 | **Tier 1** | Most complete, best timestamp preservation, natural flow | Misses Gustav Simonsson, partial AlethZero |
+| 3 | **Grok** | 2,830 | **Tier 1** | Nearly complete, good flow | Introduces "Piper Merriam" error, inconsistent capitalization, misses FreeMyVunk |
+
+### Overall Processor Rankings (WhisperX-Cloud base, Opus/Gemini/Grok only)
+
+| Rank | Processor | Words | Tier | Strengths | Weaknesses |
+|------|-----------|-------|------|-----------|------------|
+| 1 | **Gemini** | 2,704 | **Tier 1** | Bold proper noun markup, good re-segmentation | Moderate segment recovery |
+| 2 | **Opus** | 2,729 | **Tier 1** | Strong diarization recovery | Formatting artifacts |
+| 3 | **Grok** | 2,732 | **Tier 2** | Complete content | Minimal re-segmentation, wall-of-text |
+
+### Best Available Transcript
+
+**Recommendation:** `episode007-jacob-czepluch_assemblyai_gemini.md` is the best single transcript for this episode among the three assessed processors, due to its superior proper noun accuracy (uniquely correct on Gustav Simonsson and AlethZero) and clean formatting. However, `assemblyai_opus.md` is a very close second with better timestamp preservation and slightly more complete content.
+
+### Transcriber Verdict
+
+| Transcriber | Usability | Grade |
+|-------------|-----------|-------|
+| AssemblyAI | Excellent -- production-ready base | A |
+| WhisperX-Cloud | Usable but limited by coarse segmentation | C+ |
+| WhisperX (local) | Completely corrupted -- total failure | F |

--- a/outputs/episode008-michael-parenti/episode008-michael-parenti_quality_assessment.md
+++ b/outputs/episode008-michael-parenti/episode008-michael-parenti_quality_assessment.md
@@ -1,9 +1,10 @@
 # Episode 008 (Michael Parenti) -- Quality Assessment Report
 
-**Date:** 2026-02-22
+**Date:** 2026-02-23
 **Episode:** Early Days of Ethereum -- Michael Parenti interview by Bob Summerwill
 **Duration:** ~26 minutes
-**Location:** Paralelni Polis, Prague (DevCon era)
+**Location:** Paralelni Polis, Prague (HCPP / DevCon era)
+**Assessed processors:** opus, gemini, grok (per scope)
 
 ---
 
@@ -11,169 +12,237 @@
 
 Three raw transcriber outputs were assessed from `intermediates/episode008-michael-parenti/`.
 
-| Metric | WhisperX (local) | WhisperX-Cloud | AssemblyAI |
+| Metric | AssemblyAI | WhisperX (local) | WhisperX-Cloud |
 |---|---|---|---|
-| Word count | 4,380 | 4,193 | 4,596 |
-| Line count | 200 | 52 | 388 |
-| Speaker labels | SPEAKER_00, SPEAKER_01 | SPEAKER_01, SPEAKER_02 | SPEAKER_00, SPEAKER_01 |
-| Diarization granularity | Fine-grained (many short turns) | Coarse (long merged paragraphs) | Fine-grained (many short turns) |
-| Timestamp density | High (~100 timestamps) | Low (~25 timestamps) | Highest (~194 timestamps) |
+| Word count | 4,596 | 4,380 | 4,193 |
+| Line count | 388 | ~200 | 52 |
+| Speaker labels | SPEAKER_00, SPEAKER_01 | SPEAKER_00, SPEAKER_01 | SPEAKER_01, SPEAKER_02 |
+| Diarization granularity | Fine-grained (~194 turns) | Moderate (~100 turns) | Very coarse (~25 turns) |
+| Timestamp density | Highest | Moderate | Low |
 | Corruption | None | None | None |
 
 ### Transcriber Quality Notes
 
-**AssemblyAI** is the strongest transcriber base for this episode:
-- Highest word count (4,596), suggesting best capture of all spoken content.
-- Finest diarization with ~194 speaker turns, closely matching the natural conversational exchange.
-- Accurate speaker separation between the interviewer (SPEAKER_00 / Bob) and interviewee (SPEAKER_01 / Michael).
-- Clean formatting with no corruption.
+**AssemblyAI** is the strongest transcriber base:
+- Highest word count (4,596), indicating best capture of all spoken content.
+- Finest diarization with ~194 speaker turns, closely matching the natural conversational flow between interviewer (SPEAKER_00 / Bob) and interviewee (SPEAKER_01 / Michael).
+- Clean formatting with no corruption or anomalies.
+- Minor transcription errors present in the raw output: "Dark Prague" (should be "DevCon Prague" or "HCPP"), "Exalt server" (should be "Exiled Surfer"), "DEFCON 4" (should be "DevCon 4"), "Mark Capellis" (should be "Mark Karpeles"), "Charlie Schremm" (should be "Charlie Shrem").
 
-**WhisperX (local)** is good but slightly compressed:
-- 4,380 words -- about 95% of AssemblyAI.
-- Good turn-level diarization (200 lines, ~100 turns).
-- Speaker labels swapped vs. AssemblyAI (SPEAKER_01 = Bob here, SPEAKER_00 = Michael).
-- Some minor word-level differences but overall faithful.
+**WhisperX (local)** is a solid second:
+- 4,380 words -- about 95% of AssemblyAI's count.
+- Good turn-level diarization (~100 turns, ~200 lines).
+- Speaker labels use same numbering but roles are swapped: SPEAKER_01 = Bob, SPEAKER_00 = Michael.
+- Similar transcription errors to AssemblyAI; renders "Before Ethereum evolved" instead of "Before Ethereum involvement."
 
 **WhisperX-Cloud** has the weakest structure:
-- Only 52 lines total with very long merged paragraphs.
-- Conversations from both speakers are frequently collapsed into single blocks, making it difficult for AI processors to properly separate speaker turns.
-- Only ~25 timestamps, far fewer than the other two.
+- Only 52 lines total with very long merged paragraphs spanning multiple speaker turns.
+- Conversations from both speakers are frequently collapsed into single blocks, making proper speaker separation extremely difficult for downstream AI processors.
+- Only ~25 timestamps, far fewer than the other two transcribers.
 - Word count (4,193) is the lowest, suggesting some content loss.
 - Speaker labels (SPEAKER_01, SPEAKER_02) differ from the other two.
+- Same transcription errors as WhisperX local, but the coarse structure compounds the problem.
 
 ---
 
 ## 2. AI Processor Comparison -- AssemblyAI Base
 
-Max word count (excluding anomalies): ~4,701 (llama, but llama is corrupt). Effective max among valid outputs: ~4,580 (kimi).
+Max word count among assessed outputs: 4,425 (gemini).
 
-| Processor | Words | Lines | Tier | Name Corrections | Formatting | Notes |
-|---|---|---|---|---|---|---|
-| **opus** | 4,273 | 386 | **Tier 1** | Mark Karpeles, Charlie Shrem, Amir Taaki, Mike Gogulski, Lyn Ulbricht, Parallelni Polis, Gorli, Kotti, Brainbot | Excellent -- proper bold labels, timestamps, speaker separation | Preserves "Bob Samuel" and "Exalt server" from source; strong name corrections for crypto ecosystem terms |
-| **chatgpt** | 4,094 | 364 | **Tier 1** | Mark Karpeles, Charlie Shrem, Smari McCarthy, Asta Fjola, Amir Taaki, Parallelni Polis, Gorli, Kotti | Excellent -- clean em-dashes, quoted dialogue, polished punctuation | Best prose polish; corrects "Bob Summerwill"; very readable |
-| **gemini** | 4,425 | 384 | **Tier 1** | Bob Summerwill, Mark Karpeles, Smari McCarthy, Asta Helgadottir, Amir Taaki, Parallelni Polis, Gorli, Kotti | Excellent formatting | Corrects "Bob Summerwill" and "Michael Polzl" (incorrect -- should be Parenti); misidentifies the guest |
-| **deepseek** | 4,534 | 386 | **Tier 1** | Mark Karpeles, Charlie Shrem, Smari McCarthy, Asta Gudrun Helgadottir, Amir Taaki, Parallelni Polis, Gorli, Kotti | Excellent formatting | Good retention; corrects many names accurately; minor stutters preserved faithfully |
-| **grok** | 4,251 | 386 | **Tier 1** | Bob Summerwill, Mark Karpeles, Amir Taaki, Parallelni Polis | Good formatting | Misidentifies guest as "Michael Perklin"; reasonable quality overall |
-| **kimi** | 4,580 | 386 | **Tier 1** | Bob Summerwill, Mark Karpeles, Charlie Shrem, Amir Taaki | Good formatting | Misidentifies guest as "Axel something Michael Perklin"; still retains "Exalt server" awkwardness |
-| **minimax** | 4,375 | 378 | **Tier 1** | Bob Summerwill, Mark Karpeles, Amir Taaki, Parallelni Polis | Good formatting | Changes "Exalt server" to "Ethereum Czar" (creative but inaccurate); "Parallel Prague" instead of DevCon Prague |
-| **qwen** | 4,518 | 384 | **Tier 1** | Bob Summerwill, Mark Karpeles, Mihai Alisie, Charlie Shrem, Amir Taaki | Good formatting | Corrects "Exalt server Michael Paronyan" (incorrect guest name) |
-| **mistral** | 4,024 | 82 | **Tier 2** | Bob Summerwill, Mark Karpeles, Mihai Alisie, Vitalik Buterin, Gorli, Kotti | Very long paragraphs, no speaker separation | Collapsed all dialogue into ~40 paragraphs without speaker labels; content complete but diarization lost |
-| **glm** | 12,477 | 1,044 | **Tier 3** | Various | First ~550 lines are chain-of-thought reasoning, not transcript | Includes verbose internal reasoning about name corrections before the actual transcript starts around line 558; actual transcript portion is ~4,500 words and reasonable quality |
-| **llama** | 4,701 | 759 | **Tier 4** | Partial (early lines) | Corrupted after ~line 43 | First 15 lines have broken formatting (**[00:03] SPEAKER_00:]); complete gibberish/hallucination from line 43 onward; unusable |
+| Processor | Words | Lines | % of Max | Tier | Rating |
+|---|---|---|---|---|---|
+| **gemini** | 4,425 | 384 | 100% | **Tier 1** | Excellent |
+| **opus** | 4,273 | 386 | 96.6% | **Tier 1** | Excellent |
+| **grok** | 4,251 | 386 | 96.1% | **Tier 1** | Excellent |
 
----
+### Detailed Notes -- AssemblyAI Base
 
-## 3. AI Processor Comparison -- WhisperX-Cloud Base
+**gemini (Tier 1 -- Excellent)**
+- Highest word count (4,425) and most complete content retention among the three processors.
+- Excellent formatting with proper bold speaker labels, timestamps, and clean speaker turn separation.
+- Strong name corrections: corrects "Bob Summerwill" (from "Bob Samuel"), "Mark Karpeles" (from "Capellis"), "Charlie Shrem" (from "Schremm"), "Smari McCarthy" with proper accent marks on "Asta Helgadottir."
+- Correctly identifies "Devcon Prague" from the garbled "Dark Prague."
+- Problem: Misidentifies the guest as "Michael Polzl" instead of Michael Parenti. This is a significant factual error.
+- Adds appropriate quotation marks around dialogue and uses em-dashes for readability.
+- Complete from start ([00:03]) to finish ([26:07] "Bye").
 
-Max word count (excluding anomalies): ~4,276 (opus).
+**opus (Tier 1 -- Excellent)**
+- 4,273 words with 386 lines -- slightly lower word count but excellent line-level diarization matching the source.
+- Best structural fidelity: preserves the fine-grained turn-by-turn structure from AssemblyAI, maintaining all brief interjections ("Yeah", "Right, right") as separate speaker turns.
+- Name corrections: "Mark Karpeles," "Charlie Shrem," "Amir Taaki," "Mike Gogulski" (from "Michael Goolsky"), "Lyn Ulbricht," "Parallelni Polis," "DevCon Prague."
+- Retains "Exalt server Michael Parenti" from source without correcting to "Exiled Surfer" -- faithful but not corrected.
+- Retains "Bob Samuel" without correcting to "Bob Summerwill."
+- Corrects "Asta Fish" to a plausible rendering. Consistently uses "Gorli" / "Kotti" for testnet names.
+- Clean formatting throughout. Complete from start to finish.
+- Minor filler word removal compared to source but overall very faithful to spoken content.
 
-| Processor | Words | Lines | Tier | Notes |
-|---|---|---|---|---|
-| **opus** | 4,276 | 280 | **Tier 1** | Excellent; properly re-diarized the coarse cloud input back into fine-grained speaker turns; good name corrections |
-| **chatgpt** | 3,777 | 56 | **Tier 2** | Preserved the coarse paragraph structure from the cloud input; content complete but speaker turns not separated |
-| **gemini** | 4,084 | 50 | **Tier 2** | Similar to chatgpt -- preserved coarse structure; decent name corrections |
-| **deepseek** | 4,186 | 48 | **Tier 2** | Coarse structure preserved; good content retention |
-| **grok** | 3,932 | 50 | **Tier 2** | Coarse structure; reasonable quality |
-| **kimi** | 4,194 | 50 | **Tier 2** | Coarse structure; reasonable quality |
-| **llama** | 4,086 | 50 | **Tier 2** | Coarse structure; no corruption (unlike assemblyai_llama) |
-| **minimax** | 4,193 | 50 | **Tier 2** | Coarse structure; reasonable quality |
-| **mistral** | 4,187 | 50 | **Tier 2** | Similar coarse structure; same issue as assemblyai variant |
-| **qwen** | 4,102 | 50 | **Tier 2** | Coarse structure; reasonable quality |
-| **glm** | 10,450 | 302 | **Tier 3** | Again includes chain-of-thought reasoning preamble before actual transcript |
-
----
-
-## 4. AI Processor Comparison -- WhisperX (Local) Base
-
-Max word count (excluding anomalies): ~4,465 (mistral).
-
-| Processor | Words | Lines | Tier | Notes |
-|---|---|---|---|---|
-| **chatgpt** | 4,072 | 236 | **Tier 1** | Good speaker separation; clean formatting; "Bob Summerwill", "Exiled Surfer, Michael Peranty" |
-| **opus** | 4,077 | 276 | **Tier 1** | Good diarization; preserves "Bob Samuel" from source |
-| **gemini** | 4,348 | 200 | **Tier 1** | Good formatting and content |
-| **deepseek** | 4,443 | 209 | **Tier 1** | Good content retention; clean output |
-| **grok** | 4,073 | 196 | **Tier 1** | Solid quality |
-| **kimi** | 4,382 | 198 | **Tier 1** | Solid quality |
-| **llama** | 4,282 | 200 | **Tier 1** | Clean output (no corruption from this base) |
-| **minimax** | 4,373 | 198 | **Tier 1** | "Bob Summerwill"; reasonable quality |
-| **mistral** | 4,465 | 206 | **Tier 1** | Highest word count; good formatting |
-| **qwen** | 4,131 | 198 | **Tier 1** | Clean output |
-| **glm** | 4,138 | 204 | **Tier 1** | No chain-of-thought preamble from this base -- clean transcript output |
+**grok (Tier 1 -- Excellent)**
+- 4,251 words with 386 lines -- slightly lower word count but same excellent line structure.
+- Good formatting with proper bold speaker labels and timestamps.
+- Name corrections: "Bob Summerwill" (correctly identified), "Mark Karpeles," "Amir Taaki," "Parallelni Polis."
+- Problem: Misidentifies the guest as "Michael Perklin" (rendered as "Axel something Michael Perklin" in the intro). This is a significant factual error.
+- Renders "Asta Fysh" -- a phonetic approximation but not correct.
+- Names "Mike Hearn" instead of "Mike Gogulski" -- this is a factual substitution error (Mike Hearn is a different Bitcoin developer).
+- Less aggressive filler word removal than opus; preserves some stutters and conversational disfluencies.
+- Complete from start to finish.
 
 ---
 
-## 5. Consensus Pipeline
+## 3. AI Processor Comparison -- WhisperX (Local) Base
 
-**Status:** No `*_final.md` file exists. The consensus pipeline has **not been run** for this episode.
+Max word count among assessed outputs: 4,348 (gemini).
+
+| Processor | Words | Lines | % of Max | Tier | Rating |
+|---|---|---|---|---|---|
+| **gemini** | 4,348 | 200 | 100% | **Tier 1** | Excellent |
+| **opus** | 4,077 | 276 | 93.8% | **Tier 1** | Excellent |
+| **grok** | 4,073 | 196 | 93.7% | **Tier 1** | Excellent |
+
+### Detailed Notes -- WhisperX (Local) Base
+
+**gemini (Tier 1 -- Excellent)**
+- Highest word count (4,348) from this transcriber base.
+- Good formatting; 200 lines with proper speaker turns, though fewer lines than opus (276).
+- Correctly identifies "Bob Summerwill" and "ExiledSurfer" (written as one word).
+- Correctly renders "Mihai Alisie" (co-founder of Bitcoin Magazine) where raw transcript just had "Mihai."
+- Renders "Griff Green" (full name) instead of just "Griff."
+- Uses "Asta Helgadottir" -- good name correction.
+- Correctly spells "Goerli" testnet. Properly identifies "ETHBerlin," "Department of Decentralization."
+- Preserves the moderate diarization from the WhisperX source; does not further split turns.
+- Same guest name issue: renders as "Michael Peranti" -- close to correct but still slightly off.
+- Complete from start to finish.
+
+**opus (Tier 1 -- Excellent)**
+- 4,077 words across 276 lines -- the highest line count, indicating opus actively re-diarized the WhisperX input into finer speaker turns.
+- Excellent structural improvement: split several multi-speaker paragraphs from WhisperX into proper individual speaker turns.
+- Uses "Mark Karpeles" (correct), "Parallelni Polis" (correct Czech spelling), "Interspace" (the conference software).
+- Renders "Smari McCarthy" and "Asta Fish" -- reasonable phonetic renderings.
+- Preserves "Bob Samuel" without correction (same pattern as the AssemblyAI base).
+- Preserves "exiled server, Michael Peranti" -- close to correct but not fully fixed.
+- Clean, professional formatting. Consistent timestamp formatting. Complete from start to finish.
+- Best structural quality from this base due to the re-diarization.
+
+**grok (Tier 1 -- Excellent)**
+- 4,073 words across 196 lines -- comparable to gemini's structure.
+- Clean formatting with proper bold speaker labels.
+- Correctly identifies "Bob Summerwill" and renders location as "HCPP" (Hackers Congress Paralelni Polis) instead of "DevCon Prague" -- an interesting and arguably more accurate venue identification.
+- Renders guest as "Michael Perklin" -- same incorrect guess as the AssemblyAI base.
+- Uses "Asta Fylkisdottir" -- an incorrect but creative Icelandic-sounding name guess.
+- Names "Michael Goldstein" instead of "Michael Gogulski/Goolsky" -- another factual substitution error (Michael Goldstein is a different person in the Bitcoin space).
+- Renders "Gorli" for the testnet name.
+- Complete from start to finish.
 
 ---
 
-## 6. Cross-Transcriber Comparison
+## 4. AI Processor Comparison -- WhisperX-Cloud Base
 
-### Key Findings
+Max word count among assessed outputs: 4,276 (opus).
 
-**Best transcriber base: AssemblyAI**
-- Provides the finest-grained diarization (194 speaker turns), giving AI processors the best starting material.
-- Highest raw word count, capturing the most spoken content.
-- The fine-grained speaker separation allows processors to maintain accurate dialogue formatting.
+| Processor | Words | Lines | % of Max | Tier | Rating |
+|---|---|---|---|---|---|
+| **opus** | 4,276 | 280 | 100% | **Tier 1** | Excellent |
+| **gemini** | 4,084 | 50 | 95.5% | **Tier 2** | Good |
+| **grok** | 3,932 | 50 | 92.0% | **Tier 2** | Good |
 
-**WhisperX (local) is a strong second:**
-- The local WhisperX output has good diarization (~100 turns) and produces consistently high-quality AI processor outputs across all 11 models.
-- Notably, WhisperX + GLM produced a clean output (4,138 words, no preamble), unlike AssemblyAI + GLM and WhisperX-Cloud + GLM which both had chain-of-thought preamble problems.
-- WhisperX + Llama also produced a clean output (4,282 words), unlike AssemblyAI + Llama which was completely corrupted.
+### Detailed Notes -- WhisperX-Cloud Base
 
-**WhisperX-Cloud is the weakest base:**
-- The coarse paragraph structure (only 52 lines) causes most AI processors to simply preserve the same coarse structure rather than re-diarizing into proper speaker turns.
-- Only Opus (280 lines) successfully re-diarized the cloud input back into fine speaker turns.
-- Most processors produced 48-56 line outputs with very long paragraphs -- technically complete but poorly structured for readability.
+**opus (Tier 1 -- Excellent)**
+- 4,276 words across 280 lines -- opus is the only processor that successfully re-diarized the coarse 52-line cloud input back into fine-grained speaker turns.
+- This is a remarkable feat: from 52 input lines to 280 output lines, opus properly identified speaker boundaries within the merged paragraphs and split them into individual turns with correct timestamps.
+- Three speaker labels used (SPEAKER_01, SPEAKER_02, and one UNKNOWN) matching the cloud source's numbering.
+- Good name corrections: "Smari McCarthy," "Asta Fish," "Parallelni Polis," "GorliCon," "Kotti."
+- Preserves some raw transcription artifacts ("Michael Peranti," "Bob Samuel") without correction.
+- The re-diarization accurately preserves the conversational flow -- short interjections like "Yeah," "Right," "Okay" are properly separated.
+- Complete from start to finish.
 
-### Processor Consistency Across Bases
+**gemini (Tier 2 -- Good)**
+- 4,084 words but only 50 lines -- gemini preserved the coarse paragraph structure from the cloud input rather than re-diarizing.
+- Content is largely complete (95.5% of max) but readability suffers significantly.
+- Long merged paragraphs make it difficult to follow the conversational back-and-forth.
+- Does correct some names: "Smari McCarthy," "Asta Fish."
+- Renders guest as "Michael Peranti" and host as "Bob Samuel" -- same as source without correction.
+- Timestamps are sparse (~25) matching the cloud input.
+- Complete from start to finish but structurally poor.
+
+**grok (Tier 2 -- Good)**
+- 3,932 words across 50 lines -- lowest word count, suggesting some content loss during processing.
+- Like gemini, preserves the coarse paragraph structure from the cloud input.
+- Renders "Michael Paret" for the guest name -- the least accurate rendering among the three processors.
+- Renders host as "Bob Summerwill" -- correct.
+- Uses "Goerli" for the testnet (correct modern spelling).
+- Same structural problems as gemini: long paragraphs, poor readability, sparse timestamps.
+- Complete from start to finish.
+
+---
+
+## 5. Cross-Transcriber Comparison
+
+### Processor Consistency Across Bases (opus/gemini/grok)
 
 | Processor | AssemblyAI | WhisperX | WhisperX-Cloud | Consistency |
 |---|---|---|---|---|
-| opus | Tier 1 | Tier 1 | Tier 1 | Excellent -- always high quality |
-| chatgpt | Tier 1 | Tier 1 | Tier 2 | Good -- only drops on cloud input |
-| gemini | Tier 1 | Tier 1 | Tier 2 | Good -- only drops on cloud input |
-| deepseek | Tier 1 | Tier 1 | Tier 2 | Good -- only drops on cloud input |
-| grok | Tier 1 | Tier 1 | Tier 2 | Good |
-| kimi | Tier 1 | Tier 1 | Tier 2 | Good |
-| minimax | Tier 1 | Tier 1 | Tier 2 | Good |
-| qwen | Tier 1 | Tier 1 | Tier 2 | Good |
-| mistral | Tier 2 | Tier 1 | Tier 2 | Inconsistent -- collapses speaker labels on 2/3 bases |
-| llama | Tier 4 | Tier 1 | Tier 2 | Highly variable -- catastrophic failure on assemblyai base |
-| glm | Tier 3 | Tier 1 | Tier 3 | Variable -- chain-of-thought preamble on 2/3 bases |
+| **opus** | Tier 1 (4,273w / 386L) | Tier 1 (4,077w / 276L) | Tier 1 (4,276w / 280L) | **Best** -- always Tier 1; uniquely re-diarizes coarse input |
+| **gemini** | Tier 1 (4,425w / 384L) | Tier 1 (4,348w / 200L) | Tier 2 (4,084w / 50L) | Good -- drops on cloud due to preserving coarse structure |
+| **grok** | Tier 1 (4,251w / 386L) | Tier 1 (4,073w / 196L) | Tier 2 (3,932w / 50L) | Good -- drops on cloud; has name substitution errors |
 
-### Name Correction Quality
+### Key Findings
 
-A persistent challenge across all outputs is the guest's name. The audio says something like "Exiled Surfer, Michael Parenti" (or similar). Various processors rendered this as:
-- "Exalt server Michael Parenti" (opus, kimi, qwen -- preserves audio faithfully)
-- "Michael Polzl" (gemini -- incorrect guess)
-- "Michael Perklin" (grok, kimi -- incorrect guess)
-- "Michael Perlin" (glm whisperx-cloud -- incorrect guess)
-- "Michael Parantis" (mistral -- close but wrong)
-- "Ethereum Czar Michael Parenti" (minimax -- creative but inaccurate)
-- "Exiled Surfer, Michael Peranty" (chatgpt whisperx -- closest to correct)
+**Best overall processor: opus**
+- The only processor that achieves Tier 1 across all three transcriber bases.
+- Its standout capability is re-diarization: when given the coarse WhisperX-Cloud input (52 lines), opus successfully reconstructed fine-grained speaker turns (280 lines), matching the quality of its output from fine-grained inputs.
+- Most faithful to the source audio content, though this means it also preserves some transcription errors without correction (e.g., "Bob Samuel" instead of "Bob Summerwill").
+- Best structural formatting across all bases.
 
-The actual person is known as "Exiled Surfer" (his handle) and his name is Michael Perenti/Parenti. No processor fully nailed this.
+**Highest content retention: gemini**
+- Consistently produces the highest word counts from any given base (4,425 from AssemblyAI, 4,348 from WhisperX).
+- Better at name correction than opus (correctly identifies "Bob Summerwill," provides accented names).
+- However, does not re-diarize coarse inputs -- preserves whatever structure the transcriber provides.
+- Misidentifies the guest as "Michael Polzl" in one variant -- a significant factual error.
 
-Bob Summerwill's name was correctly identified by chatgpt, gemini, grok, kimi, minimax, mistral, and qwen. Opus and deepseek preserved the transcriber's "Bob Samuel" without correction.
+**Most variable: grok**
+- Solid Tier 1 on fine-grained inputs but drops to Tier 2 on coarse cloud input.
+- Has recurring name substitution errors: replaces "Mike Gogulski" with "Mike Hearn" or "Michael Goldstein" -- these are factual errors where a real but wrong person is substituted.
+- Misidentifies the guest as "Michael Perklin" across multiple outputs.
+- Lowest word count on the cloud base (3,932), suggesting some content trimming.
+
+### Name Correction Quality Comparison
+
+| Name (correct) | opus | gemini | grok |
+|---|---|---|---|
+| Bob Summerwill | "Bob Samuel" (not corrected) | "Bob Summerwill" (correct) | "Bob Summerwill" (correct) |
+| Exiled Surfer | "Exalt server" (not corrected) | "ExiledSurfer" (correct) | "exiled surfer" (mostly correct) |
+| Michael Parenti (guest) | "Michael Parenti" (correct) | "Michael Polzl" (wrong) | "Michael Perklin" (wrong) |
+| Mark Karpeles | Correct | Correct | Correct |
+| Charlie Shrem | Correct | Correct | Correct |
+| Mihai (Alisie) | "Mihai" (partial) | "Mihai Alisie" (full, correct) | "Mihai" (partial) |
+| Smari McCarthy | Correct | Correct | Correct |
+| Asta (Helgadottir) | "Asta Fish" (phonetic) | "Asta Helgadottir" (correct) | "Asta Fysh/Fylkisdottir" (wrong) |
+| Mike Gogulski | "Mike Gogulski" (correct) | "Michael Gulskis" (close) | "Mike Hearn" (wrong person) |
+| Amir Taaki | Correct | Correct | Correct |
+| Jorg Platzer | Correct (with umlaut) | Correct (with umlaut) | Correct (with umlaut) |
+| Parallelni Polis | Correct | Correct | Correct |
+| Gorli/Goerli testnet | "Gorli" | "Goerli" (correct) | "Gorli"/"Goerli" (varies) |
+
+**gemini** has the best name correction overall but critically misidentifies the guest. **opus** has the most faithful rendering of the guest name but does not correct the host name. **grok** has the most factual substitution errors where incorrect but real names are used.
 
 ---
 
-## 7. Recommendations
+## 6. Recommendations
 
-1. **Run consensus pipeline**: No final output exists. The best candidates for consensus would be the AssemblyAI-based outputs from opus, chatgpt, deepseek, and gemini.
+1. **Best single output for this episode**: `episode008-michael-parenti_assemblyai_opus.md` -- best structural fidelity, correct guest name, consistent formatting, and highest line-level diarization quality. The uncorrected "Bob Samuel" can be fixed in a manual pass.
 
-2. **Preferred single outputs** (if consensus not available):
-   - **Best overall**: `episode008-michael-parenti_assemblyai_chatgpt.md` -- best prose polish, accurate name corrections, clean formatting, and proper speaker separation.
-   - **Runner-up**: `episode008-michael-parenti_assemblyai_opus.md` -- faithful to source, excellent formatting, but retains "Bob Samuel" without correction.
-   - **Third**: `episode008-michael-parenti_assemblyai_deepseek.md` -- highest retention among clean outputs, good name corrections.
+2. **Runner-up**: `episode008-michael-parenti_assemblyai_gemini.md` -- highest word count, best name corrections for most names, but the "Michael Polzl" misidentification of the guest is a significant drawback.
 
-3. **Discard or regenerate**:
-   - `episode008-michael-parenti_assemblyai_llama.md` -- completely corrupted, unusable (Tier 4).
-   - `episode008-michael-parenti_assemblyai_glm.md` and `episode008-michael-parenti_whisperx-cloud_glm.md` -- contain chain-of-thought reasoning preamble that must be stripped before use.
+3. **Third**: `episode008-michael-parenti_assemblyai_grok.md` -- solid quality but the "Michael Perklin" guest name error and "Mike Hearn" substitution are problematic.
 
-4. **WhisperX-Cloud outputs** are generally Tier 2 due to the coarse input structure. If these are needed, `episode008-michael-parenti_whisperx-cloud_opus.md` is the only one that properly re-diarized the input.
+4. **WhisperX-Cloud outputs**: Only `episode008-michael-parenti_whisperx-cloud_opus.md` is recommended from this base. The gemini and grok cloud outputs (Tier 2) have poor structure due to preserved coarse paragraphs.
 
-5. **Name correction**: A manual pass should correct "Bob Samuel" to "Bob Summerwill" and "Exalt server" to "Exiled Surfer" across all outputs that preserved the raw transcriber error. The guest's name "Michael Parenti" should be verified against the episode metadata.
+5. **Manual corrections needed across all outputs**:
+   - "Bob Samuel" -> "Bob Summerwill" (in opus outputs)
+   - "Exalt server" -> "Exiled Surfer" (in opus outputs)
+   - "Michael Polzl" -> "Michael Parenti" (in gemini assemblyai output)
+   - "Michael Perklin" -> "Michael Parenti" (in grok outputs)
+   - "Mike Hearn" -> "Mike Gogulski" (in grok assemblyai output)
+   - "Michael Goldstein" -> "Mike Gogulski" (in grok whisperx output)
+
+6. **Consensus pipeline**: No `*_final.md` file exists. If running consensus, the recommended trio would be the AssemblyAI-based opus, gemini, and grok outputs, with manual correction of the guest name across gemini and grok before merging.

--- a/outputs/episode009-amir-taaki/episode009-amir-taaki_quality_assessment.md
+++ b/outputs/episode009-amir-taaki/episode009-amir-taaki_quality_assessment.md
@@ -1,163 +1,214 @@
-# Episode 009 (Amir Taaki) — Quality Assessment Report
+# Episode 009 (Amir Taaki) -- Quality Assessment Report
 
-## 1. Transcriber Comparison
-
-| Transcriber | Word Count | Diarization | Quality | Notes |
-|-------------|-----------|-------------|---------|-------|
-| **WhisperX local** | 8,676 | 2 speakers (SPEAKER_00, SPEAKER_02) | Good (~92%) | Clean output with proper speaker separation; good paragraph breaks; mostly accurate proper names |
-| **WhisperX-cloud** | 8,393 | 2 speakers (SPEAKER_02, SPEAKER_03) | Fair (~85%) | Merges many speaker turns into wall-of-text paragraphs; poor diarization — collapses rapid back-and-forth exchanges into single blocks |
-| **AssemblyAI** | 9,592 | 2 speakers (SPEAKER_00, SPEAKER_01) | Best (~97%) | Cleanest speaker separation with fine-grained turn-taking; best punctuation; highest word count preserving more content |
-
-**Verdict:** AssemblyAI is the clear winner for this episode. It captures the most content (9,592 words vs 8,676 for WhisperX local) and provides significantly better speaker diarization with proper turn-by-turn separation. WhisperX local is a solid second, with clean formatting and good speaker labels. WhisperX-cloud is the weakest — it frequently merges both speakers' dialogue into single long blocks, making it harder for AI processors to maintain proper speaker attribution.
+**Assessment date:** 2026-02-23
+**Assessor:** Claude Opus 4.6
+**Episode duration:** ~56:36
 
 ---
 
-## 2. AI Processor Comparison — AssemblyAI Base
+## 1. Transcriber Comparison (Raw Intermediates)
 
-Max word count for this base: 9,196 (Opus)
+| Transcriber | Word Count | Speakers | Diarization Quality | Notes |
+|-------------|-----------|----------|-------------------|-------|
+| **AssemblyAI** | 9,592 | SPEAKER_00, SPEAKER_01 | Excellent | Cleanest speaker separation with fine-grained turn-taking; best punctuation and capitalization; highest word count preserving the most verbal content; proper per-line turn separation |
+| **WhisperX (local)** | 8,676 | SPEAKER_00, SPEAKER_02 | Good | Good speaker separation with proper turn breaks; mostly accurate; some rapid exchanges well handled; minor loss vs AssemblyAI |
+| **WhisperX-cloud** | 8,393 | SPEAKER_02, SPEAKER_03 | Fair | Frequently merges both speakers' dialogue into single long paragraphs (wall-of-text); poor diarization collapses rapid back-and-forth exchanges into single blocks; lowest word count |
 
-| Processor | Words | % of Max | Completeness | Quality | Tier |
-|-----------|-------|----------|-------------|---------|------|
-| **Opus** | 9,196 | 100% | Full (56:36 timestamp) | Excellent — faithful, clean prose, correct proper names, natural flow | **Tier 1** |
-| **Kimi** | 9,105 | 99% | Full (56:36) but truncated at very end of long block | Very good — faithful, minor formatting quirks (missing spaces after timestamps) | **Tier 1** |
-| **Gemini** | 8,884 | 97% | Full (56:36) | Excellent — clean formatting, good proper name correction (Melvin Carvalho, Taylor Gerring), proper capitalization | **Tier 1** |
-| **Grok** | 8,655 | 94% | Full (56:36) | Very good — faithful, clean, proper names well handled (Zuzalu, Calafou, CIC) | **Tier 1** |
-| **ChatGPT** | 7,769 | 84% | Full (56:36) | Good — more condensed, merges some turns, good punctuation and proper names | Tier 2 |
-| **GLM** | 30,137 | 328% | **CORRUPTED** — contains AI thinking/analysis process, not a clean transcript | Unusable — 2,455 lines of reasoning notes before and around transcript output | **Tier 4** |
-| **Llama** | 5,157 | 56% | Partial (~30:00) | Decent quality where present, but truncated mid-conversation | Tier 3 |
-| **DeepSeek** | 5,066 | 55% | Partial — condensed throughout | Good quality within what exists but heavily condensed | Tier 3 |
-| **Qwen** | 5,106 | 56% | Partial — condensed throughout | Good quality, decent cleanup, but significant content loss | Tier 3 |
-| **MiniMax** | 4,523 | 49% | Partial (~28:00) | Moderate quality, truncated before halfway | Tier 3 |
-| **Mistral** | 4,080 | 44% | **Severely truncated** — ends at ~25:00 with wrong timestamps, skips ~30min of content | Incomplete, final timestamps compressed/wrong | Tier 3 |
+### Transcriber Diarization Details
 
----
+- **AssemblyAI** uses SPEAKER_00 (interviewer) and SPEAKER_01 (Amir Taaki). Turn breaks happen at nearly every conversational exchange, including very short interjections like "Right" and "Yeah." This granularity is excellent for downstream AI processing.
+- **WhisperX (local)** uses SPEAKER_00 (interviewer) and SPEAKER_02 (Amir Taaki). Good diarization overall with proper turn-level separation, comparable to AssemblyAI though slightly less granular on very short interjections.
+- **WhisperX-cloud** uses SPEAKER_03 (interviewer) and SPEAKER_02 (Amir Taaki). Severely inferior diarization -- frequently collapses multiple speakers' turns into a single speaker block. For example, the entire opening from 00:03 to 05:13 is a single SPEAKER_03 block in the raw output, merging what should be separate speaker turns. This makes accurate speaker attribution very difficult for AI processors.
 
-## 3. AI Processor Comparison — WhisperX Local Base
+### Transcriber Verdict
 
-Max word count for this base: 8,663 (Kimi)
-
-| Processor | Words | % of Max | Completeness | Quality | Tier |
-|-----------|-------|----------|-------------|---------|------|
-| **Kimi** | 8,663 | 100% | Full | Very good — faithful, proper formatting | **Tier 1** |
-| **Grok** | 8,652 | 100% | Full | Very good — clean prose, proper names | **Tier 1** |
-| **Opus** | 8,578 | 99% | Full | Excellent — highest prose quality, best proper name correction | **Tier 1** |
-| **Gemini** | 8,372 | 97% | Full | Excellent — clean formatting, good quality | **Tier 1** |
-| **ChatGPT** | 8,362 | 97% | Full | Good — more condensed but complete | **Tier 1** |
-| **GLM** | 8,091 | 93% | Full | Good — clean transcript (no thinking leak for this base) | **Tier 1** |
-| **Llama** | 5,574 | 64% | Partial | Decent quality, truncated | Tier 3 |
-| **Qwen** | 5,217 | 60% | Partial | Good quality within what exists | Tier 3 |
-| **Mistral** | 4,928 | 57% | Partial — truncated | Incomplete | Tier 3 |
-| **MiniMax** | 3,887 | 45% | Partial — severely truncated | Significant content loss | Tier 3 |
-| **DeepSeek** | 3,108 | 36% | **Severely truncated** — worst on this base | Significant content loss, lowest retention | Tier 3 |
+AssemblyAI is the clear winner for this episode. It captures the most content (9,592 words vs 8,676 and 8,393) and provides the best speaker diarization with proper turn-by-turn separation. WhisperX local is a solid second. WhisperX-cloud is the weakest due to its poor diarization merging.
 
 ---
 
-## 4. AI Processor Comparison — WhisperX-Cloud Base
+## 2. AI Processor Assessment -- AssemblyAI Base
 
-Max word count for this base: 8,549 (Opus)
+**Max word count (reference):** 9,196 (Opus)
 
-| Processor | Words | % of Max | Completeness | Quality | Tier |
-|-----------|-------|----------|-------------|---------|------|
-| **Opus** | 8,549 | 100% | Full | Excellent — clean, faithful, good proper name correction | **Tier 1** |
-| **Kimi** | 8,393 | 98% | Full | Very good — faithful, minor formatting issues | **Tier 1** |
-| **Grok** | 8,374 | 98% | Full | Very good — clean formatting, complete | **Tier 1** |
-| **Gemini** | 8,280 | 97% | Full | Excellent — clean, well-structured | **Tier 1** |
-| **ChatGPT** | 7,567 | 88% | Full | Good — more condensed | Tier 2 |
-| **Llama** | 6,475 | 76% | Mostly complete | Fair — some content loss | Tier 2 |
-| **DeepSeek** | 6,303 | 74% | Mostly complete | Fair — condensed | Tier 2 |
-| **Qwen** | 5,953 | 70% | Partial | Moderate content loss | Tier 2 |
-| **Mistral** | 5,836 | 68% | Partial | Some truncation | Tier 2 |
-| **MiniMax** | 5,676 | 66% | Partial | Some truncation | Tier 2 |
-| **GLM** | 26,222 | 307% | **CORRUPTED** — contains AI thinking/analysis process instead of clean transcript | Unusable | **Tier 4** |
+| Processor | Words | % of Max | Final Timestamp | Tier | Rating |
+|-----------|-------|----------|----------------|------|--------|
+| **Opus** | 9,196 | 100% | 56:36 | **Tier 1** | Excellent |
+| **Gemini** | 8,884 | 97% | 56:36 | **Tier 1** | Excellent |
+| **Grok** | 8,655 | 94% | 56:36 | **Tier 1** | Very Good |
 
----
+### Opus (AssemblyAI base) -- Tier 1
 
-## 5. Consensus Pipeline
+- **Completeness:** Full transcript from 00:03 to 56:36. All content preserved.
+- **Formatting:** Clean markdown with proper `**[timestamp] SPEAKER_XX:**` format. Natural paragraph breaks with consistent turn separation.
+- **Diarization fidelity:** Faithfully preserves the AssemblyAI two-speaker setup (SPEAKER_00 / SPEAKER_01). All rapid back-and-forth exchanges maintained.
+- **Proper names:** Good handling -- "Taylor Gerring," "Kieren James-Lubin," "Anthony D'Onofrio," "Melvin," "Eric Voskuil," "Pieter Wuille," "DarkFi," "Calafou," "Bitcointalk."
+- **Content accuracy:** Highest word count, preserving the most filler and natural speech. Very faithful to source. Minor cleanup of obvious speech artifacts while preserving conversational tone.
+- **Notable:** Uses "Eufemio" for Anthony's last name. Correctly identifies "ring sigs" and "ZK" at the end.
 
-**Status: NOT RUN** — No `*_final.md` file exists for this episode. The consensus pipeline has not been executed.
+### Gemini (AssemblyAI base) -- Tier 1
 
----
+- **Completeness:** Full transcript from 00:03 to 56:36. All content preserved.
+- **Formatting:** Very clean markdown. Proper structure throughout. Slightly more condensed formatting -- tends to merge some adjacent short turns into flowing blocks more than Opus.
+- **Diarization fidelity:** Faithful preservation of SPEAKER_00 / SPEAKER_01 attribution.
+- **Proper names:** Excellent -- "Melvin Carvalho" (full name identified), "Taylor Gerring," "DigixGold," "Gavin Andresen," "Nick Szabo." Strong proper name identification.
+- **Content accuracy:** 97% of max word count. Minor condensation of filler words and repeated phrases. Natural, readable result.
+- **Notable:** Adds "Melvin Carvalho" as full name where other processors just have "Melvin." Uses "Heartline" vs "Hartline." Slightly cleans up some speech disfluencies. Uses "Ring sigs" and "this" (slightly less clear than other outputs at the ZK clarification).
 
-## 6. Cross-Transcriber Comparison
+### Grok (AssemblyAI base) -- Tier 1
 
-Word counts across the same AI processor for each transcriber base:
-
-| Processor | AssemblyAI | WhisperX Local | WhisperX-Cloud | Notes |
-|-----------|-----------|---------------|----------------|-------|
-| **Opus** | 9,196 | 8,578 | 8,549 | Consistently top tier across all bases |
-| **Gemini** | 8,884 | 8,372 | 8,280 | Consistently top tier across all bases |
-| **Grok** | 8,655 | 8,652 | 8,374 | Consistent, high quality |
-| **Kimi** | 9,105 | 8,663 | 8,393 | Consistent, high quality |
-| **ChatGPT** | 7,769 | 8,362 | 7,567 | Good, slightly more condensed |
-| **GLM** | 30,137 (BROKEN) | 8,091 (OK) | 26,222 (BROKEN) | Broken on AssemblyAI and WhisperX-cloud; fine on WhisperX local |
-| **DeepSeek** | 5,066 | 3,108 | 6,303 | Inconsistent — ranges from 36% to 74% |
-| **Llama** | 5,157 | 5,574 | 6,475 | Consistently truncated |
-| **Qwen** | 5,106 | 5,217 | 5,953 | Consistently truncated |
-| **Mistral** | 4,080 | 4,928 | 5,836 | Consistently truncated; better on WhisperX-cloud base |
-| **MiniMax** | 4,523 | 3,887 | 5,676 | Consistently truncated |
-
-**Key observations:**
-
-1. **AssemblyAI produces the richest base** — Opus on AssemblyAI yields 9,196 words vs 8,578 on WhisperX local and 8,549 on WhisperX-cloud. The better diarization in AssemblyAI gives processors more to work with.
-
-2. **Top-tier processors are consistent** — Opus, Gemini, Grok, and Kimi all produce complete, high-quality output regardless of the transcriber base. These models are robust to input variation.
-
-3. **GLM has a systemic "thinking leak" issue** — On 2 of 3 transcriber bases (AssemblyAI and WhisperX-cloud), GLM outputs its internal reasoning/analysis process rather than a clean transcript. This is a catastrophic failure mode producing 3x the expected word count. On WhisperX local base, it works correctly (8,091 words), suggesting the failure is input-dependent.
-
-4. **Lower-tier processors perform slightly better on WhisperX-cloud** — DeepSeek, Mistral, and MiniMax all produce higher word counts from the WhisperX-cloud base compared to AssemblyAI or WhisperX local. This may be because WhisperX-cloud's merged paragraphs are shorter input for these models to process.
-
-5. **WhisperX-cloud's merged diarization** is not ideal — it collapses rapid back-and-forth dialogue into single speaker blocks, losing turn-taking information that the higher-quality processors correctly preserve from the other two bases.
+- **Completeness:** Full transcript from 00:03 to 56:36. All content preserved.
+- **Formatting:** Clean markdown. Good structure. Similar turn-level granularity to Opus.
+- **Diarization fidelity:** Faithful preservation of SPEAKER_00 / SPEAKER_01.
+- **Proper names:** Good -- "Taylor Gerring," "Gavin Andresen," "Calafou," "Zuzalu," "Nick Szabo," "Eric Voskuil."
+- **Content accuracy:** 94% of max word count. Slightly more aggressive in trimming filler words and verbal tics compared to Opus. Still highly faithful to the source content.
+- **Notable:** Uses "Ring signatures" (expanded from "ring sigs") and "this" at the ending. Word "ahistorical" correctly transcribed (where some versions have "historical" which reverses the meaning). Good handling of technical terms.
 
 ---
 
-## 7. Quality Notes — Specific Observations
+## 3. AI Processor Assessment -- WhisperX (local) Base
 
-### Proper Name Handling
-- **Best:** Gemini (correctly produces "Melvin Carvalho," "Taylor Gerring," "Gavin Andresen," "Pieter Wuille," "LETS," "BIPs," "Bitcointalk")
-- **Good:** Opus, ChatGPT (correct most names; Opus uses "Gerring," ChatGPT uses "Taylor Gerring")
-- **Inconsistent:** WhisperX raw uses "Gavin Andreessen" (double-s); assemblyai raw uses "Gavin Andresen" (single-s) -- the correct spelling is "Gavin Andresen"
-- **Notable:** The name "Taylor Gerring" vs "Taylor Gehring" vs "Taylor Goering" varies across transcribers and processors. The correct spelling from the Known People list is "Taylor Gerring."
+**Max word count (reference):** 8,652 (Grok)
 
-### Technical Term Accuracy
-All top-tier processors correctly handle: Ethereum, Bitcoin, Dark Wallet, Libbitcoin/libbitcoin, BIPs, CoinJoin, SourceForge, Bitcointalk, DarkFi, ZK, OTC, L1, Zcash, Monero, Ring signatures, Agora, Calafou, CIC, Zuzalu, Nick Szabo, "argument surface."
+| Processor | Words | % of Max | Final Timestamp | Tier | Rating |
+|-----------|-------|----------|----------------|------|--------|
+| **Opus** | 8,578 | 99% | 56:36 | **Tier 1** | Excellent |
+| **Gemini** | 8,372 | 97% | 56:36 | **Tier 1** | Excellent |
+| **Grok** | 8,652 | 100% | 56:36 | **Tier 1** | Very Good |
 
-### Content Integrity
-The conversation covers ~57 minutes of content across these topics:
-1. Origin of the Early Days of Ethereum project (00:00-05:00)
-2. Bitcointalk post editing controversy (05:00-09:00)
-3. Digital preservation and lost history (09:00-11:00)
-4. Amir's path to Bitcoin — poker, IRC, discovering Bitcoin source code (11:00-17:00)
-5. Conflict with Gavin Andresen, BIP system creation (17:00-20:00)
-6. Bitcoin's political factions and ossification (20:00-25:00)
-7. Squatting, anarchist hacker communities, and Calafou (25:00-28:00)
-8. Meeting Mihai, Vitalik, founding Dark Wallet (28:00-33:00)
-9. Ethereum's origins and the Toronto hackathon (33:00-45:00)
-10. Dark Wallet timeline, libbitcoin, Eric Voskuil (45:00-48:00)
-11. Ethereum critique — political philosophy, product focus, argument surface (48:00-56:00)
-12. DarkFi description and sign-off (55:00-57:00)
+### Opus (WhisperX base) -- Tier 1
 
-Truncated outputs (Tier 3) typically drop sections 7-12 entirely, losing the most analytically rich portions of the conversation.
+- **Completeness:** Full transcript from 00:03 to 56:36.
+- **Formatting:** Clean, well-structured. Uses SPEAKER_00 and SPEAKER_02 per the WhisperX source. Good turn separation.
+- **Diarization fidelity:** Faithfully follows the WhisperX speaker labels. Good handling of rapid exchanges.
+- **Proper names:** Good -- "Taylor Gerring," "Eric Voskuil," "Pieter Wuille," "DarkFi," "Calafou," "Gavin Andresen."
+- **Content accuracy:** 99% of max. Very faithful. Opening lines correctly handle the WhisperX diarization where the interviewer's first "Hello, hello" is attributed to SPEAKER_02 (a minor diarization error in the source that Opus preserves faithfully).
+- **Notable:** Uses "Devcon Prague Zero" in one variant (whisperx_grok) but this Opus output correctly has "Dark Prague Zero."
+
+### Gemini (WhisperX base) -- Tier 1
+
+- **Completeness:** Full transcript from 00:03 to 56:36.
+- **Formatting:** Clean and well-structured. Consistent formatting throughout.
+- **Diarization fidelity:** Faithful to source. Good speaker attribution.
+- **Proper names:** Good handling. Uses "AMAs" (misidentified from audio "Amirs") in the opening, which is a minor error.
+- **Content accuracy:** 97% of max. Some condensation of filler. Clean, readable output.
+- **Notable:** Similar quality to the Gemini AssemblyAI-based output.
+
+### Grok (WhisperX base) -- Tier 1
+
+- **Completeness:** Full transcript from 00:03 to 56:36.
+- **Formatting:** Clean markdown. Good structure.
+- **Diarization fidelity:** Faithful to source.
+- **Proper names:** Good -- though has "Devcon Prague" instead of "Dark Prague" in the opening, which is an error. Uses "RingCT" instead of "ring sigs" at the end.
+- **Content accuracy:** Highest word count of the WhisperX-based outputs (100%). Very faithful.
+- **Notable:** The "Devcon Prague" error is notable -- the whisperx_grok output introduces this misidentification where the source says "Dark Prague." Uses formatting like backticks around `main.cpp` and quotes around key phrases, which is a nice touch.
 
 ---
 
-## 8. Recommendations
+## 4. AI Processor Assessment -- WhisperX-cloud Base
 
-### Best Available Transcript
-**`episode009-amir-taaki_assemblyai_opus.md`** — This is the highest quality output available:
-- 9,196 words (100% of max)
-- Complete coverage through 56:36
-- Excellent speaker separation
-- Faithful to original speech while cleaning up filler
-- Correct proper name handling
-- Clean, consistent formatting
+**Max word count (reference):** 8,549 (Opus)
 
-### Runner-Up Options
-1. **`episode009-amir-taaki_assemblyai_gemini.md`** — 8,884 words, excellent formatting, slightly better proper name precision (Melvin Carvalho surname added)
-2. **`episode009-amir-taaki_assemblyai_chatgpt.md`** — 7,769 words, more condensed but complete, good editorial quality
-3. **`episode009-amir-taaki_assemblyai_grok.md`** — 8,655 words, clean and complete
+| Processor | Words | % of Max | Final Timestamp | Tier | Rating |
+|-----------|-------|----------|----------------|------|--------|
+| **Opus** | 8,549 | 100% | 56:34 | **Tier 1** | Excellent |
+| **Gemini** | 8,280 | 97% | 56:36 | **Tier 1** | Good |
+| **Grok** | 8,374 | 98% | 56:36 | **Tier 1** | Good |
 
-### Action Items
-1. **Run consensus pipeline** — Not yet executed for this episode. Given the issues seen in episode 012, word-level consensus may not be the right approach; consider using the best single processor output (Opus or Gemini) as the final instead.
-2. **Fix GLM thinking leak** — GLM's failure on 2 of 3 bases (producing 26K-30K word reasoning dumps instead of ~9K word transcripts) should be investigated. The system prompt may need to be more explicit about suppressing chain-of-thought output.
-3. **Address Mistral timestamp compression** — Mistral's AssemblyAI output compresses 57 minutes into ~25 minutes of timestamps, indicating it's silently dropping content rather than properly truncating with a warning.
-4. **Consider dropping Tier 3/4 processors** — DeepSeek, Llama, Qwen, MiniMax, and Mistral consistently produce 36-66% retention across all bases. For cost efficiency, these could be dropped from the pipeline for this episode type (long-form interview).
+### Opus (WhisperX-cloud base) -- Tier 1
+
+- **Completeness:** Full transcript from 00:03 to 56:34. Complete coverage.
+- **Formatting:** Clean markdown. Uses SPEAKER_02 and SPEAKER_03 per source. Better turn separation than the raw source -- Opus does a good job inferring speaker turns from the wall-of-text blocks that WhisperX-cloud produces.
+- **Diarization fidelity:** Actually improves on the source by separating merged speaker blocks back into individual turns. Speaker attribution is reasonable given the poor source diarization.
+- **Proper names:** Good -- "Taylor Gerring," "Eric Voskuil," "DarkFi," "Calafou," "Nick Szabo."
+- **Content accuracy:** Highest word count for this base. Faithful to source content.
+- **Notable:** The timestamps differ slightly from other bases (e.g., 00:47 vs 00:56 for the first speaker change) due to the different diarization source. Opus handles the poor WhisperX-cloud diarization admirably, reconstructing sensible speaker turns.
+
+### Gemini (WhisperX-cloud base) -- Tier 1
+
+- **Completeness:** Full transcript from 00:03 to 56:36. Only 72 lines total due to the wall-of-text formatting inherited from WhisperX-cloud.
+- **Formatting:** Very long paragraphs -- inherits the poor diarization from WhisperX-cloud. Speaker turns are frequently merged into single massive blocks. This is the main weakness.
+- **Diarization fidelity:** Poor -- directly mirrors the WhisperX-cloud's poor speaker separation. Does not attempt to re-separate merged turns.
+- **Proper names:** Good handling within the text.
+- **Content accuracy:** 97% of max. Content is all there but the formatting is hard to follow due to merged speaker turns.
+- **Notable:** With only 72 lines, this output has the wall-of-text problem. Long monolithic blocks make it difficult to distinguish who is speaking when.
+
+### Grok (WhisperX-cloud base) -- Tier 1
+
+- **Completeness:** Full transcript from 00:03 to 56:36. Also 72 lines.
+- **Formatting:** Same wall-of-text issue as Gemini on this base. Long merged blocks.
+- **Diarization fidelity:** Poor -- mirrors the WhisperX-cloud source. Does not fix the merged speaker turns.
+- **Proper names:** Good. Uses "Dev Prague" instead of "Dark Prague" in one instance (same error as its WhisperX local variant).
+- **Content accuracy:** 98% of max. Content is preserved.
+- **Notable:** Also has "Dev Prague" error. Similar formatting issues to Gemini on this base. The wall-of-text format is a significant readability problem.
+
+---
+
+## 5. Cross-Base Comparison
+
+### Word Count Summary
+
+| Base / Processor | Opus | Gemini | Grok |
+|-----------------|------|--------|------|
+| **AssemblyAI** | 9,196 | 8,884 | 8,655 |
+| **WhisperX (local)** | 8,578 | 8,372 | 8,652 |
+| **WhisperX-cloud** | 8,549 | 8,280 | 8,374 |
+
+### Formatting Quality (lines)
+
+| Base / Processor | Opus | Gemini | Grok |
+|-----------------|------|--------|------|
+| **AssemblyAI** | 800 | 678 | 794 |
+| **WhisperX (local)** | 406 | 436 | 404 |
+| **WhisperX-cloud** | 332 | 72 | 72 |
+
+Higher line counts generally indicate better turn-level separation. AssemblyAI-based outputs have the best turn granularity. WhisperX-cloud Gemini and Grok outputs are severely compressed into wall-of-text blocks (72 lines for a 57-minute conversation).
+
+### Key Observations
+
+1. **AssemblyAI base consistently produces the best outputs.** All three processors achieve Tier 1 on the AssemblyAI base, with the highest word counts and best formatting granularity.
+
+2. **Opus is the most faithful processor across all bases.** It consistently preserves the most content and, critically, does the best job of recovering speaker turns from poorly diarized sources (WhisperX-cloud).
+
+3. **WhisperX-cloud base is problematic.** While Opus manages to partially recover from the poor diarization (332 lines), Gemini and Grok inherit the wall-of-text problem directly (72 lines each). This makes WhisperX-cloud-based outputs from Gemini and Grok significantly less usable despite their content being complete.
+
+4. **Grok introduces the "Devcon Prague" / "Dev Prague" error** on both WhisperX bases, misidentifying "Dark Prague" as "Devcon Prague" or "Dev Prague." This is a notable factual error.
+
+5. **Gemini excels at proper name identification**, particularly adding "Melvin Carvalho" as a full name on the AssemblyAI base, and correctly rendering "DigixGold" and other proper nouns.
+
+6. **The word "ahistorical" is a critical test** -- Amir says Ethereum's approach is "very ahistorical" (lacking historical awareness). Some outputs render this as "historical" which reverses the meaning. Grok (AssemblyAI base) correctly uses "ahistorical."
+
+---
+
+## 6. Recommended Best Output
+
+**Primary recommendation:** `episode009-amir-taaki_assemblyai_opus.md`
+- Highest word count (9,196)
+- Best turn-level granularity (800 lines)
+- Most faithful to source material
+- Clean formatting with proper speaker attribution
+- Complete coverage (00:03 to 56:36)
+
+**Secondary recommendation:** `episode009-amir-taaki_assemblyai_gemini.md`
+- Slightly more polished proper names (Melvin Carvalho full name)
+- 97% word count with cleaner prose
+- Complete coverage
+
+**Avoid:** WhisperX-cloud based Gemini and Grok outputs due to wall-of-text formatting that collapses speaker turns into unreadable blocks.
+
+---
+
+## 7. Tier Summary
+
+All nine assessed outputs achieve Tier 1 (Complete, >90% of max word count, good to excellent quality). However, quality varies significantly in formatting and diarization fidelity:
+
+| Output | Tier | Effective Quality |
+|--------|------|-------------------|
+| assemblyai_opus | Tier 1 | Excellent -- best overall |
+| assemblyai_gemini | Tier 1 | Excellent |
+| assemblyai_grok | Tier 1 | Very Good |
+| whisperx_opus | Tier 1 | Excellent |
+| whisperx_gemini | Tier 1 | Good (minor "AMAs" error) |
+| whisperx_grok | Tier 1 | Good ("Devcon Prague" error) |
+| whisperx-cloud_opus | Tier 1 | Good (recovered diarization) |
+| whisperx-cloud_gemini | Tier 1 | Fair (wall-of-text format) |
+| whisperx-cloud_grok | Tier 1 | Fair (wall-of-text + "Dev Prague" error) |

--- a/outputs/episode011-ryan-taylor/episode011-ryan-taylor_quality_assessment.md
+++ b/outputs/episode011-ryan-taylor/episode011-ryan-taylor_quality_assessment.md
@@ -1,160 +1,160 @@
-# Episode 011 (Ryan Taylor) — Quality Assessment Report
+# Episode 011 (Ryan Taylor) -- Quality Assessment Report
 
-**Assessment Date:** 2026-02-22
-**Episode Duration:** ~71 minutes
-**Topic:** Ryan Taylor (SPEAKER_00) interviews Bob Summerwill (SPEAKER_01) about the "Early Days of Ethereum" project, web development with AI tools, Ethereum history, and Ryan's own involvement building the original ethereum.org website.
-
----
-
-## 1. Transcriber Comparison
-
-Only **one transcriber** (AssemblyAI) was used for this episode. No WhisperX or WhisperX-cloud outputs exist.
-
-| Transcriber | File | Word Count | Lines | Status |
-|---|---|---|---|---|
-| AssemblyAI (consensus intermediate) | `intermediates/.../episode011-ryan-taylor_assemblyai_consensus.md` | 13,266 | 722 | Complete, no corruption |
-
-### AssemblyAI Quality Notes
-
-- **Diarization:** Two speakers (SPEAKER_00, SPEAKER_01) are consistently and correctly identified throughout. Speaker turns are well-segmented.
-- **Timestamps:** Consistent format using `[MM:SS]` for sub-hour and `[H:MM:SS]` for post-hour content. Timestamps appear accurate and well-distributed.
-- **Filler words:** Some natural speech artifacts retained (e.g., "uh," "um," "you know") which is appropriate for a verbatim transcript.
-- **Proper nouns:** Reasonable accuracy for domain-specific terms: "Ethereum," "Vitalik," "ConsenSys," "Hackers Congress," "Paralelní Polis," etc. Minor issues with some names (e.g., "Paraloni Polis" instead of "Paralelni Polis").
-- **No corruption detected:** No garbled text, no missing segments, no encoding issues. The transcript runs cleanly from [00:01] to [1:11:39].
-- **Completeness:** Full coverage of the entire conversation from greeting to closing.
+**Assessment Date:** 2026-02-23
+**Episode Duration:** ~71 minutes (00:01 to 1:11:39)
+**Host:** Ryan Taylor (SPEAKER_00)
+**Guest:** Bob Summerwill (SPEAKER_01)
+**Topics:** Early Days of Ethereum website project, AI-assisted web development, Ethereum history and forgotten contributors, social history vs. great man theory, decentralized storage (IPFS, Filecoin, MaidSafe, Florincoin, LBRY), Internet Archive and digital preservation, the original ethereum.org website, Skype data preservation, ZK AV Club recording station at Dark Prague
 
 ---
 
-## 2. AI Processor Comparison
+## 1. Transcriber Assessment
 
-### 2.1 Per-Model Quality Scores (from pipeline assessment)
+Only **one transcriber** (AssemblyAI) was used for this episode. No WhisperX or WhisperX-Cloud outputs exist.
 
-The pipeline ran **10 AI models** on the AssemblyAI transcript. Quality assessment results from `episode011-ryan-taylor_ai_quality_assessment.json`:
+### Available Raw Files
+
+| File | Format | Size | Word-Level Entries |
+|---|---|---|---|
+| `episode011-ryan-taylor_assemblyai_opus.srt` | SRT with color tags | 683 KB (50,176 lines) | 12,544 subtitle entries |
+| `episode011-ryan-taylor_assemblyai_opus.ass` | ASS (Advanced SubStation) | 720 KB | 12,546 dialogue entries |
+
+### Diarization Quality
+
+| Metric | Value |
+|---|---|
+| Speakers Detected | 2 (Speaker00 / Speaker01) |
+| Speaker00 Word Entries (SRT) | 5,589 |
+| Speaker01 Word Entries (SRT) | 6,955 |
+| Speaker00 Word Entries (ASS) | 5,590 |
+| Speaker01 Word Entries (ASS) | 6,956 |
+| SRT/ASS Consistency | Matched (1 entry offset from header/format lines) |
+
+**Diarization Notes:**
+- Two speakers are correctly and consistently identified throughout the entire recording.
+- Color coding in SRT (`\c&HFFF000&` for Speaker00, `\c&HCC55FF&` for Speaker01) matches ASS style definitions (Speaker00 = cyan/yellow, Speaker01 = purple).
+- Speaker turns are well-segmented at the word level with proper per-word timestamps.
+- The opening exchange confirms correct speaker assignment: Speaker00 says "Hello, Bob" (Ryan is the host), Speaker01 says "How are you, Ryan?" (Bob is the guest).
+- No third-speaker contamination detected.
+- Coverage runs from 00:00:01.199 to 01:11:39.130 with no gaps or missing time ranges.
+- No encoding errors, garbled text, or corruption found in either format.
+
+### Transcriber Verdict
+
+AssemblyAI provides clean, consistent, word-level diarization with correct speaker assignment and full temporal coverage. The raw material is suitable for AI processing. The absence of a second transcriber (WhisperX) means there is no independent verification of diarization accuracy.
+
+---
+
+## 2. AI Processor Assessment
+
+### 2.1 Pipeline Quality Scores (from `episode011-ryan-taylor_ai_quality_assessment.json`)
+
+The pipeline evaluated 10 AI models on the AssemblyAI transcript. Input word count: 12,544. Consensus word count: 12,708.
 
 | Model | Word Count | Input Preservation | Consensus Alignment | Quality Score | Rank |
 |---|---|---|---|---|---|
-| **Grok** | 12,184 | 0.626 | 0.526 | **0.698** | 1 (Top 5) |
-| **Llama** | 5,810 | 0.632 | 0.588 | **0.671** | 2 (Top 5) |
-| **GLM** | 12,544 | 1.000 | 0.146 | **0.659** | 3 (Top 5) |
-| **Opus** | 12,009 | 0.556 | 0.463 | **0.652** | 4 (Top 5) |
-| **Mistral** | 4,928 | 0.549 | 0.542 | **0.621** | 5 (Top 5) |
-| Gemini | 12,133 | 0.881 | 0.121 | 0.613 | 6 |
+| **Grok** | 12,184 | 0.626 | 0.526 | **0.698** | 1 |
+| Llama | 5,810 | 0.632 | 0.588 | 0.671 | 2 |
+| GLM | 12,544 | 1.000 | 0.146 | 0.659 | 3 |
+| **Opus** | 12,009 | 0.556 | 0.463 | **0.652** | 4 |
+| Mistral | 4,928 | 0.549 | 0.542 | 0.621 | 5 |
+| **Gemini** | 12,133 | 0.881 | 0.121 | **0.613** | 6 |
 | MiniMax | 4,671 | 0.539 | 0.521 | 0.608 | 7 |
 | Kimi | 9,807 | 0.576 | 0.170 | 0.519 | 8 |
-| ChatGPT | 10,308 | 0.032 | 0.030 | 0.322 | 9 (Bottom 3) |
-| DeepSeek | 80 | 0.009 | 0.009 | 0.207 | 10 (Bottom 3) |
+| ChatGPT | 10,308 | 0.032 | 0.030 | 0.322 | 9 |
+| DeepSeek | 80 | 0.009 | 0.009 | 0.207 | 10 |
 
-**Key Observations:**
-- **DeepSeek** produced only 80 words -- essentially a failed/empty output. Classified as unusable.
-- **ChatGPT** achieved full word count (10,308) but extremely low input preservation (0.032) and consensus alignment (0.030), suggesting it heavily paraphrased or rewrote the content rather than preserving the original transcript.
-- **GLM** achieved perfect input preservation (1.000) but very low consensus alignment (0.146), suggesting it may have simply copied the input verbatim with minimal processing.
-- **Grok** achieved the best balance of word count, input preservation, and consensus alignment.
+**Pipeline Observations:**
+- **Grok** scored highest overall with the best balance between input preservation and consensus alignment.
+- **GLM** achieved perfect input preservation (1.000) but very low consensus alignment (0.146), suggesting it essentially copied the input verbatim with minimal correction.
+- **Gemini** had strong input preservation (0.881) but the lowest consensus alignment among full-length outputs (0.121), suggesting it made corrections that diverged from what other models agreed on.
+- **ChatGPT** produced near-full word count (10,308) but almost zero input preservation (0.032) and consensus alignment (0.030), indicating heavy paraphrasing or rewriting rather than transcript correction.
+- **DeepSeek** produced only 80 words -- a total failure.
 
 ### 2.2 Output File Assessment
 
-Two `.md` outputs exist in the outputs directory:
+Only **one** processed output exists in the outputs directory:
 
-#### `episode011-ryan-taylor_assemblyai_opus.md` — **Tier 1**
+#### `episode011-ryan-taylor_assemblyai_opus.md` -- Tier 1
 
 | Metric | Value |
 |---|---|
 | Word Count | 12,102 |
-| Lines | 708 |
-| % of Input Words | 91.2% |
-| Timestamp Format | `[MM:SS]` / `[H:MM:SS]` (correct) |
+| Line Count | 708 |
+| Speaker Turns | 355 (178 SPEAKER_00, 177 SPEAKER_01) |
+| Time Range | [00:01] to [1:11:39] |
+| % of Input Words | 96.5% (12,102 / 12,544) |
 
-**Quality Assessment:**
-- **Completeness:** Full transcript from [00:01] to [1:11:39]. No missing segments. Covers the entire ~71-minute conversation.
-- **Formatting:** Consistent bold timestamps and speaker labels throughout. Clean paragraph breaks between speaker turns. No structural anomalies.
-- **Speaker Labels:** Two speakers (SPEAKER_00 / SPEAKER_01) used consistently and correctly. No mislabeled turns observed.
-- **Prose Quality:** Excellent. Natural speech is preserved while removing excessive filler words ("uh," "um") and false starts. Sentences read fluently. Proper nouns are corrected and capitalized correctly (e.g., "Paralelni Polis" -> "Paralelni Polis," "Scooby Doo" -> "Scooby-Doo," "Kieran James-Lubin," "Taylor Gerring," "BlockApps," "ConsenSys").
-- **Technical Accuracy:** Domain-specific terminology is handled well: Ethereum Foundation, crowd sale, white paper, ICO, IPFS, BitTorrent, Florincoin, LBRY, MaidSafe, Internet Archive, Wayback Machine, Jekyll, GitHub Actions, GitHub Pages.
-- **No artifacts:** No duplicated text, no truncated speaker tags, no encoding errors, no garbled passages.
-- **Timestamp Format:** Properly uses `H:MM:SS` format for times over 1 hour (e.g., `[1:06:55]`).
+**Completeness:** Full transcript from [00:01] to [1:11:39]. No missing segments, no gaps in coverage. Covers the entire ~71-minute conversation from greeting through closing. All 355 speaker turns are present with proper attribution.
 
-**Tier: 1** -- Exceeds 90% of input word count with excellent quality. This is a high-fidelity, publication-ready transcript.
+**Formatting:**
+- Consistent format throughout: `**[MM:SS] SPEAKER_XX:**` for sub-hour, `**[H:MM:SS] SPEAKER_XX:**` for post-hour timestamps.
+- Timestamps are monotonically increasing with no out-of-order entries.
+- The transition from `MM:SS` to `H:MM:SS` format occurs correctly at the 1-hour mark (e.g., `[59:36]` followed later by `[1:00:22]`).
+- Clean paragraph breaks between every speaker turn.
+- No truncated speaker tags (no `SPEAKER_` without a number).
+- No extra/phantom speakers (only SPEAKER_00 and SPEAKER_01).
 
----
+**Prose Quality:**
+- Excellent readability. Natural speech patterns are preserved while excessive filler words ("uh," "um") are appropriately cleaned.
+- Sentences flow naturally and are grammatically coherent.
+- Proper nouns are correctly handled: Ethereum, Vitalik, ConsenSys, Paralelni Polis, Scooby-Doo, Bitcoin Magazine, Bitcoin Miami, Hackers Congress, Institute of Crypto Anarchy, ZK AV Club, BlockApps, Kieren James-Lubin, Taylor Gerring, Anthony D'Onofrio ("Texture"), Kyle Kabbagovich, CoinTalk, Brewster Kahle, Jason Scott, MaidSafe, Filecoin, Florincoin, LBRY, IPFS, BitTorrent, Internet Archive, Wayback Machine, Jekyll, GitHub Actions, GitHub Pages, Dark Prague, MaidSafeCoin, Mastercoin, Bitcoin Decentral, Duke Nukem Forever.
+- Technical terminology is accurate: crowd sale, white paper, ICO, static HTML, markdown, GitHub repo, Haskell client, Red Wedding (Ethereum event reference), Frontier, Solidity.
 
-#### `episode011-ryan-taylor_final.md` — **Tier 2**
+**Artifacts:**
+- No duplicated text or paragraphs.
+- No spurious quotation marks or punctuation artifacts.
+- No unresolved variant spellings.
+- No encoding errors or garbled passages.
+- No lowercase sentence starts at speaker turn boundaries.
 
-| Metric | Value |
-|---|---|
-| Word Count | 12,587 |
-| Lines | 559 (fewer lines = longer paragraphs, more merged segments) |
-| % of Input Words | 94.9% |
-| Timestamp Format | `[M:SS]` / `[MM:SS]` (minutes-only, no hour separator) |
+**Assessment: Tier 1** -- Complete (96.5% of input words), artifact-free, properly formatted, publication-ready transcript.
 
-**Quality Assessment:**
-- **Completeness:** Full transcript from [0:01] to [71:38]. Covers the entire conversation.
-- **Formatting:** Uses bold timestamps and speaker labels. However, several structural issues are present.
-- **Speaker Labels:** Generally correct, but one truncated speaker tag found at line 123: text ends with "SPEAKER_" (incomplete tag).
-- **Prose Quality:** Mixed. While much of the content reads well, several artifacts are present:
-  - **Duplicated text** at line 63: The passage about "found this guy on Upwork, you know, he wasn't cheap, but he was good. But we spent like 100k probably on those three sites" is duplicated verbatim within the same paragraph.
-  - **Spurious quotation marks** appear in multiple places where they do not belong (e.g., `website."`, `Ethereum?"`, `hallucination."`, `same?"`, `lame."`, `available?"`, `below,"`, `you."` used as inline corrections/variants rather than actual quotes).
-  - **Em-dash correction artifacts** in several places: `characters—especially`, `below,"`, `something…"`, `Git—this`, showing visible inline correction marks.
-  - **Duplicate/variant words** visible: `earlydaysofeth—Early Early`, `Onofrio, Onofrio,`, `Taylor Gearing Gerring`, `Mihaly`, suggesting the consensus pipeline merged variant spellings without resolving them cleanly.
-  - **Incomplete sentences/fragments** at line 257: "exists." We had LBRY, sprung up at the same time. Shortly after, inspired by our project. price. They had a massive pre mine."
-  - **Lowercase sentence starts** in several places (e.g., "man of mystery", "met guy in a pub", "making, quite a bit of sacrifice", "it was just this last year").
-- **Technical Accuracy:** Generally good on domain terms but shows the merging artifacts listed above.
-- **Timestamp Format Issue:** Uses minutes-only format throughout (e.g., `[67:16]` instead of `[1:07:16]`), which is non-standard for timestamps over 60 minutes. This makes the transcript inconsistent with the opus output.
+#### Gemini and Grok Outputs -- Not Available
 
-**Tier: 2** -- Word count is high (94.9% of input), but visible consensus merging artifacts, duplicated text, spurious punctuation, and unresolved variant spellings reduce quality below the opus output. Usable but would benefit from manual cleanup.
+No `_assemblyai_gemini.md` or `_assemblyai_grok.md` files exist in the outputs directory. Despite Grok scoring highest in the pipeline quality assessment (0.698) and Gemini placing 6th (0.613), neither was rendered to a final output file. Only the Opus processor output was carried through to completion.
+
+This is a notable gap: the top-ranked pipeline model (Grok) does not have a corresponding output file for direct quality comparison.
 
 ---
 
-## 3. Consensus Pipeline Assessment
+## 3. Cross-Transcriber Comparison
 
-The consensus pipeline **was executed** and produced `episode011-ryan-taylor_final.md`. Supporting data files exist:
+**Not applicable.** Only one transcriber (AssemblyAI) was used for this episode. No WhisperX or WhisperX-Cloud intermediates exist. This means:
+- No independent verification of speaker diarization accuracy.
+- No cross-validation of word-level transcription accuracy.
+- No ability to compare how different transcriber bases affect downstream AI processing quality.
 
-- `intermediates/.../episode011-ryan-taylor_ai_consensus_words.json` (1.2MB+)
-- `intermediates/.../episode011-ryan-taylor_final_words.json` (1.5MB+)
-- `intermediates/.../episode011-ryan-taylor_intermediate_consensus_words.json`
-- `intermediates/.../episode011-ryan-taylor_assemblyai_consensus_words.json` (1.2MB+)
-- `outputs/.../episode011-ryan-taylor_final_words.json` (1.6MB)
-
-### Pipeline Performance
-
-The consensus pipeline aggregated outputs from 10 AI models (with the top 5 being Grok, Llama, GLM, Opus, and Mistral). While this produced a transcript with the highest word count (12,587), the merging process introduced several artifacts:
-
-| Issue | Count | Severity |
-|---|---|---|
-| Text duplication | 1 confirmed (line 63) | High |
-| Truncated speaker tags | 1 (`SPEAKER_` at line 123) | Medium |
-| Unresolved variant spellings | ~5 instances | Medium |
-| Spurious quotation marks | ~8+ instances | Low-Medium |
-| Lowercase sentence starts | ~6+ instances | Low |
-| Minutes-only timestamps | Systematic (all post-60min) | Low |
-
-**Verdict:** The consensus pipeline successfully combined model outputs but the merging/resolution step introduced artifacts that are not present in the single-model Opus output. The final output is lower quality than the Opus-only output despite having a slightly higher word count.
+For reference, the neighboring episode (episode010-viktor-tron) used three transcribers (WhisperX local, WhisperX-Cloud, AssemblyAI) and produced 10 output files (3 transcribers x 3 processors + 1 assessment). Episode 011 has only 1 output file plus this assessment.
 
 ---
 
-## 4. Cross-Transcriber Comparison
+## 4. Summary
 
-**Not applicable.** Only one transcriber (AssemblyAI) was used for this episode. No WhisperX or alternative transcriber outputs exist for comparison.
+| Output | Words | Lines | Turns | Coverage | Tier | Key Strength | Key Weakness |
+|---|---|---|---|---|---|---|---|
+| `_assemblyai_opus.md` | 12,102 | 708 | 355 | 00:01 - 1:11:39 | **Tier 1** | Clean, artifact-free, proper timestamps, excellent prose | Only output; no comparison possible |
 
----
+### Overall Episode Quality: Tier 1
 
-## 5. Summary Comparison
-
-| Output | Word Count | Lines | Tier | Strengths | Weaknesses |
-|---|---|---|---|---|---|
-| `_assemblyai_opus.md` | 12,102 | 708 | **Tier 1** | Clean, no artifacts, proper timestamps, excellent prose | Slightly lower word count than final |
-| `_final.md` | 12,587 | 559 | **Tier 2** | Highest word count, full coverage | Duplicated text, merging artifacts, truncated speaker tag, spurious punctuation, non-standard timestamps |
+The single available output (`episode011-ryan-taylor_assemblyai_opus.md`) is a high-quality, publication-ready transcript. It preserves 96.5% of the source word count with no detectable artifacts, correct speaker attribution, proper timestamp formatting, and excellent prose quality. The conversation content -- covering Ethereum history, the Early Days of Ethereum project, AI-assisted web development, and digital preservation -- is rendered clearly and accurately.
 
 ---
 
-## 6. Recommendations
+## 5. Recommendations
 
-1. **Use `episode011-ryan-taylor_assemblyai_opus.md` as the canonical transcript.** It is cleaner, artifact-free, and has proper timestamp formatting. The consensus final introduced more problems than it solved for this episode.
+1. **Add WhisperX transcription.** Running WhisperX (local and/or cloud) on the source audio would provide independent diarization verification and enable cross-transcriber quality comparison. This is the single most impactful improvement for this episode.
 
-2. **Consider re-running the consensus pipeline** with stricter deduplication and variant resolution to eliminate the merging artifacts found in the final output.
+2. **Generate Gemini and Grok processor outputs.** The pipeline quality assessment shows Grok scored highest (0.698) but has no rendered output. Producing `_assemblyai_gemini.md` and `_assemblyai_grok.md` would enable direct quality comparison with the Opus output and potentially identify a superior result.
 
-3. **Add a second transcriber (WhisperX)** for cross-validation. Having only one transcriber source means there is no independent verification of diarization accuracy or word-level correctness.
+3. **Investigate failed models.** DeepSeek (80 words) and ChatGPT (0.032 input preservation) should be investigated:
+   - DeepSeek appears to have completely failed to process the transcript.
+   - ChatGPT's near-zero preservation suggests wholesale rewriting rather than transcript correction.
+   - These models should be flagged or excluded from any consensus pipeline for this episode.
 
-4. **Investigate DeepSeek and ChatGPT failures.** DeepSeek produced only 80 words (essentially failed), and ChatGPT's near-zero input preservation suggests it may have hallucinated or completely rewritten the transcript. These models should be flagged or excluded from consensus for this episode.
+4. **Verify proper noun accuracy.** Several names should be cross-referenced with the Early Days of Ethereum website for correctness:
+   - "Kyle Kabbagovich" -- likely "Kyle Kurbegovic" or similar; verify spelling.
+   - "Paralelni Polis" vs. "Paralelni Polis" -- confirm diacritics.
+   - "Kieren James-Lubin" vs. "Kieran James-Lubin" -- confirm spelling.
 
-5. **Fix timestamp format in the final output.** If the final is to be retained, timestamps over 60 minutes should use `H:MM:SS` format (e.g., `1:07:16`) rather than minutes-only format (e.g., `67:16`).
-
-6. **Manual review of proper nouns.** Key names to verify: Paralelni Polis (vs. Paraloni Polis), Kieren James-Lubin (vs. Kieran James), Taylor Gerring (vs. Goering/Gearing), Anthony D'Onofrio ("Texture"), Kyle Kurbegovic, Brewster Kahle (vs. Kael/Kale).
+5. **Speaker name resolution.** SPEAKER_00 is Ryan Taylor (host) and SPEAKER_01 is Bob Summerwill (guest). Future processing could replace generic speaker labels with actual names for improved readability.

--- a/outputs/episode012-fabian-vogelsteller/episode012-fabian-vogelsteller_quality_assessment.md
+++ b/outputs/episode012-fabian-vogelsteller/episode012-fabian-vogelsteller_quality_assessment.md
@@ -1,126 +1,205 @@
-# Episode 012 (Fabian Vogelsteller) — Quality Assessment Report
+# Episode 012 (Fabian Vogelsteller) -- Quality Assessment Report
 
-## 1. Transcriber Comparison
+Generated: 2026-02-23
 
-| Transcriber | Status | Quality | Notes |
-|-------------|--------|---------|-------|
-| **WhisperX local** | **BROKEN** | Unusable | Output is entirely exclamation marks (`!!!!!!`) — complete corruption |
-| **WhisperX-cloud** | Good | ~95% | Clean output, merges some speaker turns, preserves more natural speech fillers |
-| **AssemblyAI** | Best | ~97% | Cleanest speaker separation, better proper name handling, more publication-ready |
+## 1. Source Files Inventory
 
-**Verdict:** AssemblyAI is the clear winner. WhisperX local is completely unusable for this episode. WhisperX-cloud is serviceable but AssemblyAI produces cleaner diarization and more consistent results.
+### Intermediates (raw transcriber outputs)
+| File | Words | Status |
+|------|-------|--------|
+| `episode012-fabian-vogelsteller_assemblyai.md` | 19,193 | Good |
+| `episode012-fabian-vogelsteller_whisperx-cloud.md` | 19,063 | Good |
+| `episode012-fabian-vogelsteller_whisperx.md` | 405 | CORRUPTED |
+| `ep012-small/ep012-small_whisperx-cloud.md` | (subset) | N/A |
 
----
-
-## 2. AI Processor Comparison (AssemblyAI base)
-
-| Processor | Words | Completeness | Quality | Tier |
-|-----------|-------|-------------|---------|------|
-| **GLM5** | 17,665 | 100% (452 lines) | Excellent prose, faithful, complete | **Tier 1** |
-| **Grok** | 18,474 | 100% (390 lines) | Excellent formatting, no issues | **Tier 1** |
-| **Opus** | 18,837 | 100% | High quality, faithful to original | **Tier 1** |
-| **GLM** | 19,191 | ~85% (394 lines) | Very good quality, slightly truncated | Tier 2 |
-| **Kimi** | 12,009 | ~72% (276 lines) | Very good quality, truncated mid-conversation | Tier 2 |
-| **ChatGPT** | 11,177 | Complete | Good quality, more condensed, better punctuation | Tier 2 |
-| **Gemini** | 11,175 | Complete | Good quality, clean formatting | Tier 2 |
-| **Llama** | 6,364 | ~39% (150 lines) | Severely truncated | Tier 3 |
-| **Qwen** | 6,035 | ~39% (150 lines) | Severely truncated | Tier 3 |
-| **Mistral** | 5,614 | ~36% (138 lines) | Severely truncated | Tier 3 |
-| **DeepSeek** | 5,001 | Limited | Good within what exists, very condensed | Tier 3 |
-| **MiniMax** | 3,386 | ~26% (98 lines) | Severely truncated, poorest output | **Tier 4** |
-
-**Key finding:** The critical differentiator is **completeness**, not prose quality. All models produce decent English when they're generating text — the problem is that 5 of 11 models (Llama, Qwen, Mistral, DeepSeek, MiniMax) truncate severely, losing 60-75% of the transcript. This is likely a context window or output token limit issue.
-
-**Top 3 processors:** GLM5, Grok, Opus — all produce complete, high-quality output.
+### Outputs (AI-processed transcripts)
+| File | Words | Lines |
+|------|-------|-------|
+| `assemblyai_opus.md` | 18,837 | 536 |
+| `assemblyai_grok.md` | 18,474 | 390 |
+| `assemblyai_gemini.md` | 11,175 | 344 |
+| `whisperx-cloud_opus.md` | 18,116 | 456 |
+| `whisperx-cloud_grok.md` | 18,232 | 264 |
+| `whisperx-cloud_gemini.md` | 5,837 | 222 |
+| `whisperx_opus.md` | 33 | N/A |
+| `whisperx_grok.md` | 61 | N/A |
+| `whisperx_gemini.md` | 403 | N/A |
 
 ---
 
-## 3. Consensus Pipeline — BROKEN
+## 2. Transcriber Quality Assessment
 
-The 6-phase AI consensus pipeline produced a **severely corrupted** final output:
+### AssemblyAI (19,193 words) -- BEST
+- **Diarization:** Two-speaker model (SPEAKER_00, SPEAKER_01). Clean, consistent separation between host and guest.
+- **Text quality:** Accurate word-level transcription. Proper sentence structure preserved. Some minor ASR artifacts (e.g., "findura" for "Feindura", "Pandura" instead of "Fyndura", "Jan Laborer" for "Yann Levreau") but overall strong.
+- **Timestamps:** Well-aligned, per-segment timestamps at natural turn boundaries.
+- **Speaker attribution:** Correctly distinguishes the two main speakers throughout. Short interjections properly attributed.
+- **Format:** Clean markdown with `**[MM:SS] SPEAKER_XX:**` format. One long paragraph per speaker turn.
 
-| Metric | Value | Issue |
-|--------|-------|-------|
-| Input words | 18,882 | Healthy baseline |
-| AI consensus output | 61,512 | **3.26x expansion** — catastrophic! |
-| Consensus alignment | 0.4% - 1.3% | Virtually zero agreement between models |
+### WhisperX-Cloud (19,063 words) -- GOOD
+- **Diarization:** Multi-speaker model (SPEAKER_00, SPEAKER_01, SPEAKER_02, SPEAKER_03, SPEAKER_UNKNOWN). More speakers detected than actually present.
+- **Text quality:** Comparable word accuracy to AssemblyAI. Preserves more conversational fillers and natural speech patterns (e.g., profanity is transcribed where AssemblyAI sometimes omits it).
+- **Timestamps:** Well-aligned but slightly different boundary decisions than AssemblyAI.
+- **Speaker attribution:** More fragmented. The guest is labeled SPEAKER_02 (not SPEAKER_01 as in AssemblyAI). Occasional SPEAKER_UNKNOWN and SPEAKER_03 insertions for brief interjections that may belong to main speakers.
+- **Format:** Same markdown format. Tends to merge more content into single speaker turns, producing fewer but longer segments.
+- **Key difference:** The WhisperX-cloud output frequently merges the host's short comments into the guest's speaking turn, which makes speaker boundaries less clear than AssemblyAI.
 
-### What went wrong
+### WhisperX Local (405 words) -- COMPLETELY CORRUPTED
+- **Content:** Almost entirely exclamation marks (`!!!!!!!!!!!!`). Only a handful of actual words survive ("so so so so!", "Bye. Thank you.", "Thank you. Bye.").
+- **Timestamps:** Present but meaningless since no actual transcription occurred.
+- **Root cause:** Likely a model failure or incorrect model configuration during local WhisperX processing.
+- **Impact:** All three whisperx-based AI outputs (whisperx_opus, whisperx_grok, whisperx_gemini) are unusable since they were derived from corrupted input.
 
-1. **12 divergent AI models** each applied different corrections with different word boundaries
-2. **Loose time alignment tolerance** (0.5s) created massive alignment buckets where words couldn't be reliably matched
-3. **Cascading corruption** — once alignment drifted in early sections, it propagated through the entire transcript
-4. The output contains duplicated fragments, garbled word order, and broken sentences:
-   ```
-   you great, to great see to you . We, saw each other at DevConnect
-   in November , I think ? That s not going to come out of my mouth .
-   Great to see you . We saw each other at Devconnect in saw each other
-   at DeadConnect .
-   ```
-
-**Root cause:** The word-level consensus voting algorithm fundamentally cannot work when the AI models disagree this much. With only 0.4-1.3% alignment between models, there's no meaningful consensus to build.
-
----
-
-## 4. Whisperx-Cloud vs AssemblyAI (Detailed)
-
-Word counts are remarkably similar across both transcriber bases, indicating comparable audio capture:
-
-| Processor | AssemblyAI words | Whisperx-Cloud words |
-|-----------|-----------------|---------------------|
-| Opus | 18,837 | 18,116 |
-| Grok | 18,474 | 18,232 |
-| GLM | 19,191 | 19,063 |
-| GLM5 | 17,665 | 18,982 |
-| ChatGPT | 11,177 | 11,840 |
-| Kimi | 12,009 | 11,916 |
-| Gemini | 11,175 | 5,837 |
-| Llama | 6,364 | 6,263 |
-| Qwen | 6,035 | 6,020 |
-| Mistral | 5,614 | 5,644 |
-| MiniMax | 3,386 | 6,033 |
-| DeepSeek | 5,001 | 2,478 |
-
-**AssemblyAI advantages:** Cleaner speaker separation, better punctuation standardization, more publication-ready.
-**Whisperx-Cloud advantages:** Preserves more natural speech patterns and conversational fillers, more faithful to actual spoken cadence.
+**Transcriber verdict:** AssemblyAI is the superior base for this episode. It provides cleaner two-speaker diarization, better proper noun handling, and more consistent speaker attribution. WhisperX-cloud is a viable alternative with comparable word counts but messier speaker labels.
 
 ---
 
-## 5. Automated Quality Scores
+## 3. AI Processor Quality Assessment
 
-From the AI quality assessment JSON (consensus pipeline metrics):
+### AssemblyAI-based outputs
 
-| Model | Quality Score | Input Preservation | Consensus Alignment |
-|-------|--------------|-------------------|-------------------|
-| Mistral | 0.60 | 1.00 | 0.004 |
-| GLM | 0.40 | 0.41 | 0.007 |
-| Kimi | 0.38 | 0.37 | 0.007 |
-| GLM5 | 0.35 | 0.33 | 0.008 |
-| Opus | 0.33 | 0.29 | 0.009 |
-| Grok | 0.31 | 0.27 | 0.009 |
-| DeepSeek | 0.31 | 0.27 | 0.010 |
-| Llama | 0.31 | 0.27 | 0.010 |
-| ChatGPT | 0.30 | 0.26 | 0.010 |
-| MiniMax | 0.30 | 0.26 | 0.010 |
-| Qwen | 0.30 | 0.25 | 0.013 |
-| Gemini | 0.30 | 0.25 | 0.013 |
+#### assemblyai_opus (18,837 words, 536 lines) -- TIER 1
+- **Completeness:** 100%. Covers the full conversation from introduction through to the closing remarks at [1:55:50].
+- **Opening:** Clean, faithful reproduction of the greeting and pronunciation discussion.
+- **Closing:** Ends naturally with the farewell exchange ("Thank you. Thank you.").
+- **Formatting:** Consistent `**[MM:SS] SPEAKER_XX:**` format. Long speaker turns broken into well-structured paragraphs for readability.
+- **Name corrections:** Excellent. Properly renders "Fyndura", "Frozeman", "Alex Van de Sande", "Yann Levreau", "Marek", "Waldemarstrasse", "AlethZero", "AlethBrowser", "Mist", "Web3.js", "ERC-20", "ERC-725", "Geth", "Christoph Jentzsch", "Lefteris Karapetsas". Most proper nouns are correctly identified and consistently spelled.
+- **Content fidelity:** Very high. Preserves the conversational tone while cleaning up speech artifacts. Does not over-edit or add invented content.
+- **Speaker labels:** Maintains the original two-speaker model (SPEAKER_00 as host, SPEAKER_01 as Fabian).
+- **Notable issues:** None significant.
 
-**Note:** These automated scores heavily weight `input_preservation` (how much of the original text was kept unchanged). Mistral scores highest (1.0 preservation) because it barely changed anything — this doesn't necessarily mean it produced the best transcript. The consensus alignment scores are catastrophically low across the board (0.4-1.3%), confirming the consensus pipeline failure.
+#### assemblyai_grok (18,474 words, 390 lines) -- TIER 1
+- **Completeness:** 100%. Full coverage from opening to closing at [1:55:50].
+- **Opening:** Faithful reproduction of the greeting.
+- **Closing:** Ends with the complete farewell exchange.
+- **Formatting:** Same speaker-timestamp format. Slightly more compact than Opus, with longer paragraphs and fewer line breaks between segments.
+- **Name corrections:** Generally good but slightly less precise than Opus. Uses "Frozen man" / "Pandura" in some places (carried from raw ASR). "Jan Laborer" instead of "Yann Levreau". "fbrowser" instead of "AlethBrowser". "Aleth 0" / "Aleth Zero" vary in formatting.
+- **Content fidelity:** High. Stays very close to the raw transcriber output with minimal editorial changes.
+- **Speaker labels:** Maintains two-speaker model.
+- **Notable issues:** Less aggressive name correction than Opus. Preserves some ASR errors that Opus corrects.
+
+#### assemblyai_gemini (11,175 words, 344 lines) -- TIER 2
+- **Completeness:** 100% temporal coverage. Reaches the final timestamp at [1:55:50]. However, significantly condensed at 59% of the max word count (vs Opus's 18,837).
+- **Opening:** Clean, well-formatted.
+- **Closing:** Complete farewell exchange present.
+- **Formatting:** Same speaker-timestamp format. Notably more condensed prose -- Gemini aggressively removes verbal fillers, repetitions, and false starts while preserving meaning.
+- **Name corrections:** Excellent. "Feindura" (reasonable alternate spelling), "frozeman", "Aaron Davis" (added surname), "Jeffrey Wilcke" (added surname), "Marek Kotewicz" (added surname), "Christian Reitwiessner" (added surname), "Lefteris Karapetsas" (correctly spelled), "Gustav Simonsson" (added surname), "Felix Lange" (added surname), "Gavin Wood" (added surname), "Martin Becze" (correct), "Arvicco", "Currency Coin". Gemini adds full names where the raw transcript only had first names -- this is impressive contextual knowledge.
+- **Content fidelity:** Good but significantly edited. Gemini rewrites conversational prose into more polished, publication-ready text. Removes substantial amounts of verbal filler and repetition. The meaning is preserved but the speaking style is somewhat lost.
+- **Speaker labels:** Maintains two-speaker model.
+- **Notable issues:** The condensation means roughly 40% of the spoken words are removed. While this produces cleaner prose, it sacrifices the raw conversational texture that makes oral history transcripts valuable.
+
+### WhisperX-Cloud-based outputs
+
+#### whisperx-cloud_opus (18,116 words, 456 lines) -- TIER 1
+- **Completeness:** 100%. Full coverage from [00:01] to [1:55:53].
+- **Opening:** Clean reproduction. Properly attributes the guest's pronunciation correction to SPEAKER_02.
+- **Closing:** Complete farewell exchange present.
+- **Formatting:** Same format, but uses SPEAKER_00/SPEAKER_02 labeling from the WhisperX-cloud base (SPEAKER_01 appears rarely as an interjection speaker).
+- **Name corrections:** Excellent. "Fyndura", "Frozman", "AlethZero", "Yann Levreau", "Marek Kotewicz", "Christoph Jentzsch", "Lefteris", "Felix Lange", "Gustav", "Dominic Williams", "Martin Becze". Comparable quality to assemblyai_opus.
+- **Content fidelity:** Very high. Preserves profanity and natural speech patterns from the WhisperX-cloud base while still cleaning up artifacts.
+- **Notable issues:** Some speaker attribution confusion inherited from the WhisperX-cloud base (SPEAKER_01 appears for brief interjections that should probably be attributed to SPEAKER_00 or SPEAKER_02).
+
+#### whisperx-cloud_grok (18,232 words, 264 lines) -- TIER 1
+- **Completeness:** 100%. Full coverage from [00:01] to [1:55:51].
+- **Opening:** Clean. Some speaker turns merged (host greeting + guest response combined).
+- **Closing:** Complete farewell exchange.
+- **Formatting:** Same format. Uses the WhisperX-cloud multi-speaker labels. Notably fewer lines (264 vs 456 for Opus) due to longer merged paragraphs.
+- **Name corrections:** Adequate. "Findura" (different spelling), "Frozman", "Yann LeCun" (INCORRECT -- confuses with the AI researcher), "Alethio" (incorrect -- should be AlethZero), "Ollama" (should be "OpenClaw" or "Claude Code"). Some notable name confusions.
+- **Content fidelity:** High. Stays close to the source with modest cleanup.
+- **Notable issues:** The "Yann LeCun" error is significant -- it conflates the Remix developer Yann Levreau with the famous AI researcher Yann LeCun. "Ollama" confusion with "OpenClaw" also notable. These name errors lower the quality compared to Opus and assemblyai outputs.
+
+#### whisperx-cloud_gemini (5,837 words, 222 lines) -- TIER 2
+- **Completeness:** 100% temporal coverage. Reaches [1:55:51]. However, severely condensed at only 31% of the max word count.
+- **Opening:** Clean, well-formatted.
+- **Closing:** Complete farewell exchange.
+- **Formatting:** Same format. Extremely condensed prose -- far more aggressive than even the assemblyai_gemini output.
+- **Name corrections:** Excellent. Adds full names throughout: "Jeffrey Wilcke", "Marek Kotewicz", "Christian Reitwiessner", "Lefteris Karapetsas", "Gustav Simonsson", "Felix Lange", "Dominic Williams", "Martin Becze", "Kevin Owocki", "Igor Artamonov", "Yann Levreau" (correctly spelled). Impressive contextual knowledge.
+- **Content fidelity:** Significantly rewritten. Gemini condenses paragraphs of conversational speech into tight summaries. While accurate in meaning, the output reads more like meeting minutes than a transcript. The conversational character is largely lost.
+- **Speaker labels:** Simplified -- collapses the multi-speaker WhisperX labels into a cleaner presentation.
+- **Notable issues:** At 5,837 words (vs 18,000+ for complete outputs), roughly 70% of the spoken content has been removed. This is too aggressive for an oral history transcript.
+
+### WhisperX Local-based outputs -- ALL UNUSABLE (TIER 4)
+
+| Output | Words | Assessment |
+|--------|-------|-----------|
+| `whisperx_opus.md` | 33 | AI correctly identified input as corrupted; produced minimal output |
+| `whisperx_grok.md` | 61 | Same -- AI flagged input corruption |
+| `whisperx_gemini.md` | 403 | Same -- AI attempted to work with corrupted input but produced nothing usable |
+
+These outputs correctly reflect their corrupted source material and should be disregarded.
 
 ---
 
-## 6. Recommendations
+## 4. Transcriber Base Comparison (Side by Side)
 
-### For the normal pipeline (Pipeline 1)
-- **Best combo: AssemblyAI + Opus** (or Grok, or GLM5) — consistently complete, high-quality output
-- Avoid Llama, Qwen, Mistral, MiniMax as post-processors — they truncate too aggressively
-- ChatGPT and Gemini are decent middle ground (complete but more condensed)
+Comparing the same AI processor (Opus) across both viable transcriber bases:
 
-### For the consensus pipeline (Pipeline 3)
-- The current algorithm is fundamentally broken for this episode
-- **Quick fix:** Add a validation gate — if consensus alignment < 5%, abort and fall back to the intermediate consensus (which was clean at 18,882 words)
-- **Better fix:** Reduce from 12 to 3-5 high-quality models (Opus, Grok, GLM5) which produce similar-length outputs and would align better
-- **Structural fix:** Tighten the time tolerance from 0.5s, and add word-count expansion limits (halt if output exceeds 150% of input)
+| Aspect | AssemblyAI + Opus | WhisperX-Cloud + Opus |
+|--------|-------------------|----------------------|
+| **Word count** | 18,837 | 18,116 |
+| **Line count** | 536 | 456 |
+| **Speaker model** | 2 speakers (00, 01) | 3+ speakers (00, 01, 02, UNKNOWN) |
+| **Speaker clarity** | Cleaner -- host/guest clearly separated | Messier -- guest is SPEAKER_02, brief interjections create SPEAKER_01/UNKNOWN noise |
+| **Profanity** | Partially preserved | Fully preserved |
+| **Verbal fillers** | Moderately cleaned | More preserved |
+| **Name accuracy** | Excellent | Excellent |
+| **Timestamps** | Slightly different boundaries | Slightly different boundaries |
+| **Content gaps** | None detected | None detected |
 
-### Overall best output for this episode
-The individual `assemblyai_opus.md` transcript is the best available output — complete, well-formatted, and faithful to the original conversation.
+Both produce complete, high-quality transcripts. The AssemblyAI base produces a slightly cleaner result due to its simpler and more accurate two-speaker diarization model. The WhisperX-cloud base preserves slightly more of the raw conversational texture.
+
+---
+
+## 5. Tier Summary
+
+| Tier | Criteria | Outputs |
+|------|----------|---------|
+| **Tier 1** | Complete (>90% of max word count), excellent quality | `assemblyai_opus` (18,837w), `assemblyai_grok` (18,474w), `whisperx-cloud_opus` (18,116w), `whisperx-cloud_grok` (18,232w) |
+| **Tier 2** | Complete temporal coverage, good quality but significantly condensed | `assemblyai_gemini` (11,175w), `whisperx-cloud_gemini` (5,837w) |
+| **Tier 3** | N/A for this episode | -- |
+| **Tier 4** | Unusable | `whisperx_opus` (33w), `whisperx_grok` (61w), `whisperx_gemini` (403w) |
+
+---
+
+## 6. Detailed Quality Notes
+
+### Name handling across processors
+
+| Name (correct) | assemblyai_opus | assemblyai_grok | assemblyai_gemini | whisperx-cloud_grok |
+|----------------|-----------------|-----------------|-------------------|---------------------|
+| Fyndura/Feindura | Fyndura | findura/Pandura | Feindura | Findura |
+| Frozeman | Frozeman | Frozen man | frozeman | Frozman |
+| Yann Levreau | Yann Levreau | Jan Laborer | Yann Levreau | Yann LeCun (WRONG) |
+| AlethZero | AlethZero | Aleth 0/Aleth Zero | Aleph0 | Alethio (WRONG) |
+| Alex van de Sande | Alex Van de Sande | Alex van de Sande | Alex van de Sande | Alex van de Sande |
+| Jeffrey Wilcke | Jeffrey (no surname) | Jeffrey (no surname) | Jeffrey Wilcke | Jeffrey (no surname) |
+| Waldemarstrasse | Waldemarstrasse | Waldemar Strasse | Waldemarstrasse | Waldemar Strasse |
+| C++ developer | C++ developer | C developer | C++ developer | C++ developer |
+| ERC-20 | ERC-20 | ERC-20 | ERC-20 | ERC-20 |
+
+**Best name handling:** Gemini (adds full surnames from contextual knowledge) > Opus (corrects ASR errors accurately) > Grok (stays closer to raw ASR, preserves some errors).
+
+### Content fidelity spectrum
+
+From most faithful to most condensed:
+1. **Grok** -- stays very close to raw ASR, minimal edits, preserves verbal fillers and false starts
+2. **Opus** -- moderate cleanup of speech artifacts, paragraphs added for readability, faithful to content
+3. **Gemini** -- aggressive condensation, removes 40-70% of verbal content, adds contextual knowledge (full names), rewrites for clarity
+
+---
+
+## 7. Recommendations
+
+### Best output for this episode
+**`assemblyai_opus.md`** -- The combination of AssemblyAI's clean diarization with Opus's careful editing produces the most complete, accurate, and readable transcript. At 18,837 words across 536 lines, it captures the full ~1h56m conversation with faithful reproduction of the conversational tone.
+
+### Runner-up
+**`assemblyai_grok.md`** -- Nearly identical completeness (18,474 words) with slightly less name correction. A good alternative if a more raw/unedited feel is preferred.
+
+### For condensed reading
+**`assemblyai_gemini.md`** -- At 11,175 words, this provides a well-edited, name-enriched summary of the conversation. Best suited for readers who want the substance without the conversational texture.
+
+### Issues to address
+1. **WhisperX local is broken** for this episode -- the transcriber produced corrupted output and all downstream outputs are unusable.
+2. **whisperx-cloud_grok** contains significant name errors ("Yann LeCun" instead of "Yann Levreau", "Alethio" instead of "AlethZero") that could propagate misinformation.
+3. **Gemini outputs** are too condensed for archival oral history purposes, though they demonstrate impressive contextual knowledge in adding full names.

--- a/outputs/episode012-martin-becze/episode012-martin-becze_quality_assessment.md
+++ b/outputs/episode012-martin-becze/episode012-martin-becze_quality_assessment.md
@@ -1,18 +1,27 @@
-# Episode 012 (Martin Becze) — Quality Assessment Report
+# Episode 012 (Martin Becze) -- Quality Assessment Report
+
+**Date:** 2026-02-23
+**Assessed by:** Claude Opus 4.6 (self-assessment)
+
+---
 
 ## 1. Transcriber Comparison
 
-| Transcriber | Words | Diarization | Quality | Notes |
-|-------------|-------|-------------|---------|-------|
-| **AssemblyAI** | 4,113 | Excellent (2 speakers, fine-grained) | Best | Clean timestamps, proper speaker turns, no corruption |
-| **WhisperX local** | 3,754 | Good (2 speakers, fine-grained) | Good | Slightly fewer words; occasionally merges short exchanges into previous speaker block |
-| **WhisperX-cloud** | 3,627 | Poor (2 speakers, coarse) | Adequate | Long monolithic paragraphs with both speakers merged; speaker labels swap mid-conversation; significantly fewer speaker turns |
+Three raw transcriber outputs are available in `intermediates/episode012-martin-becze/`.
 
-**Observations:**
+| Transcriber | Words | Lines | Diarization | Quality |
+|-------------|-------|-------|-------------|---------|
+| **AssemblyAI** | 4,113 | ~200 | Excellent (2 speakers, fine-grained turns) | **Best** |
+| **WhisperX local** | 3,754 | ~100 | Good (2 speakers, fine-grained turns) | Good |
+| **WhisperX-cloud** | 3,627 | ~54 | Poor (2 speakers, coarse paragraph-level) | Adequate |
 
-- **AssemblyAI** provides the best diarization with granular speaker turns and consistent SPEAKER_00/SPEAKER_01 assignment. SPEAKER_00 is Bob Summerwill (interviewer), SPEAKER_01 is Martin Becze (guest). Timestamps are accurate and well-spaced.
-- **WhisperX local** has good diarization with proper per-turn timestamps. Matches AssemblyAI's speaker assignment. Slightly fewer words overall.
-- **WhisperX-cloud** has significant diarization problems: it groups long stretches of dialogue (sometimes 3-4 minutes) under a single speaker label, merging both interviewer and guest speech. Speaker labels appear swapped in places (e.g., SPEAKER_01 contains Bob's introduction text). This makes it harder for AI processors to correctly attribute dialogue.
+### Transcriber Quality Details
+
+**AssemblyAI:** Clean, well-structured output with proper per-turn speaker labels. SPEAKER_00 is Bob Summerwill (interviewer), SPEAKER_01 is Martin Becze (guest). Timestamps are frequent and accurate. Each conversational turn gets its own labeled block, including short interjections like "Right" and "Yeah." No corruption detected. Raw transcription errors include "Bob Sumuel" (should be "Summerwill"), "Baxter"/"Bexe" (should be "Becze"), "Mavis Davis" (should be "Kumavis"/"Aaron Davis"), "List 0" (should be "AlethZero"), "godns" (should be "GeoDNS"), "back say" for the pronunciation discussion. Overall, the diarization is excellent and word accuracy is good.
+
+**WhisperX local:** Also fine-grained with proper per-turn speaker labels. Speaker assignment matches AssemblyAI (SPEAKER_00 = Bob, SPEAKER_01 = Martin). Slightly fewer words than AssemblyAI. Occasionally merges short exchanges into the previous speaker's block. Raw errors include "Bexer"/"Bexay" (should be "Becze"), "ALS0" (should be "AlethZero"), "a theorem" (whisper misrecognition in cloud variant, not present in local). Timestamps are accurate and properly spaced.
+
+**WhisperX-cloud:** Severe diarization issues. Groups 3-4 minutes of dialogue under a single speaker label, merging both interviewer and guest speech into long monolithic paragraphs. Speaker labels are swapped: SPEAKER_01 contains Bob's introduction, SPEAKER_00 contains Martin's responses -- the inverse of the other two transcribers. Only 54 lines total versus ~200 for AssemblyAI. Makes it significantly harder for AI processors to correctly attribute dialogue. Same "Bexer"/"Bexay" name issues. Fewest words overall.
 
 **Verdict:** AssemblyAI is the best transcriber base for this episode. WhisperX local is a competent secondary source. WhisperX-cloud's poor diarization degrades downstream processor quality.
 
@@ -20,153 +29,156 @@
 
 ## 2. AI Processor Comparison (AssemblyAI base)
 
-Max word count among normal outputs (excluding GLM anomaly): 4,101 (Llama)
+Three processor outputs available. Max word count: 4,093 (Gemini).
 
-| Processor | Words | % of Max | Quality | Tier |
-|-----------|-------|----------|---------|------|
-| **Gemini** | 4,093 | 100% | Excellent — correct name "Martin Becze," good formatting, "Codius" for Ripple VM, proper technical terms | **Tier 1** |
-| **Llama** | 4,101 | 100% | Excellent — complete, good formatting, correct "Joseph Chow," proper technical terms throughout | **Tier 1** |
-| **MiniMax** | 4,089 | 100% | Good — complete, but misidentifies guest as "Martin Holst Swende" (wrong person entirely); "PoA node" instead of "full node" | Tier 2 |
-| **Grok** | 4,074 | 99% | Excellent — complete, proper formatting, correct "Codius" identification, clean prose | **Tier 1** |
-| **Mistral** | 4,026 | 98% | Good — nearly complete, uses "Aaron Davis" for Kumavis (real name), "Codius" correct, some merged timestamps | Tier 2 |
-| **Deepseek** | 3,883 | 95% | Good — complete, but replaces "Joseph Chow" with "Joseph Lubin" throughout (factual error) | Tier 2 |
-| **Qwen** | 3,869 | 94% | Good — complete, clean formatting, em-dashes, correct technical terms throughout | **Tier 1** |
-| **Opus** | 3,850 | 94% | Excellent — complete, "PoC 0" and "Kumavis" correct, "DAOhub" for community group, very clean prose | **Tier 1** |
-| **ChatGPT** | 3,702 | 90% | Excellent — polished prose, proper quotation marks, "AlethZero," "a16z," "Kumavis" all correct | **Tier 1** |
-| **Kimi** | 3,689 | 90% | Good — complete, slightly condensed, correct names and terms, "Codius" identified | Tier 2 |
-| **GLM** | 27,771 | N/A | **UNUSABLE** — contains chain-of-thought reasoning instead of transcript; 9,530 lines of analysis notes, no actual clean output | **Tier 4** |
+| Processor | Words | % of Max | Lines | Completeness | Tier |
+|-----------|-------|----------|-------|-------------|------|
+| **Gemini** | 4,093 | 100% | 384 | Complete (00:02 to 25:34) | **Tier 1** |
+| **Grok** | 4,074 | 100% | 378 | Complete (00:02 to 25:34) | **Tier 1** |
+| **Opus** | 3,850 | 94% | 382 | Complete (00:02 to 25:34) | **Tier 1** |
 
-**Key findings:**
-- GLM is completely unusable — it dumped its internal reasoning/analysis process instead of producing a clean transcript. This is a severe model failure mode.
-- DeepSeek has a notable factual error: it consistently replaces "Joseph Chow" with "Joseph Lubin" throughout the transcript. Joseph Chow is the correct name (early EthereumJS contributor who later built BTC Relay); Joseph Lubin is an entirely different person (ConsenSys founder).
-- MiniMax misidentifies the guest as "Martin Holst Swende" (the Geth security lead) instead of Martin Becze — a critical name error.
-- Most processors correctly identified "ETH Dev" from the raw "FDev" in the transcript.
-- The name pronunciation discussion ("Becze"/"Bexe"/"Bexy") is handled differently by each processor, with varying success.
+### AssemblyAI Processor Details
 
-**Top processors:** ChatGPT, Opus, Gemini, Grok, Llama, Qwen — all complete with excellent quality and no critical errors.
+**Gemini (Tier 1):** Complete coverage from start to finish. Correct rendering of "Martin Becze" in the opening. Retains the pronunciation discussion with quotation marks around phonetic variants. Correctly identifies "AlethZero" (from raw "Aleth 0"), "EthDev" (from raw "ETH Dev"), "GoDNS," "DAOs and DACs." Uses "Aaron Davis" for Kumavis -- this is the contributor's real name, technically correct. Identifies Ripple's VM project as "Codius" (correct). Consistent formatting with bold timestamps and speaker labels. Uses `node-ethereum` in backticks. Minor: retains some filler phrases ("like, you know"), preserves natural speech patterns faithfully.
+
+**Grok (Tier 1):** Complete coverage. Correct "Martin Becze" identification. Uses "Codius" for Ripple VM (correct). Retains "Kumavis Davis" -- a blend of handle and surname. "Aleth 0" left somewhat ambiguous. Formatting is clean and consistent. Uses "Bexe" in opening line (from raw transcript) but does not attempt to correct it. Slightly more faithful to the raw transcript wording, preserving speech disfluencies. Retains "dapps" where raw says "dax" (DACs would be more accurate in context). Minor: some sentence fragments preserved from raw.
+
+**Opus (Tier 1):** Complete coverage. Clean, polished prose with minimal filler words removed while preserving conversational tone. Correctly identifies "PoC 0" (Proof of Concept Zero), "Kumavis" (using the well-known handle), "DAOhub" for the community group. Uses "GoDNS" consistently. Renders "Becze" correctly throughout. Speaker attribution is clean with natural dialogue flow. The pronunciation discussion is handled clearly. Slightly fewer words (94% of max) reflects editorial tightening rather than content loss -- all topics are covered through the final "Thank you, Bob" exchange.
+
+**Quality comparison:** All three are excellent, complete transcripts covering the full ~25 minutes. Gemini and Grok are slightly more verbose (preserving more filler), while Opus is slightly more editorially polished. Gemini has the best technical term correction ("Codius," "AlethZero," backticked code references). Grok is most faithful to raw speech. Opus has the cleanest reading experience.
 
 ---
 
 ## 3. AI Processor Comparison (WhisperX local base)
 
-Max word count (excluding GLM anomaly): 3,800 (Gemini)
+Three processor outputs available. Max word count: 3,800 (Gemini).
 
-| Processor | Words | % of Max | Quality | Tier |
-|-----------|-------|----------|---------|------|
-| **Gemini** | 3,800 | 100% | Good — complete, correct names, proper formatting | **Tier 1** |
-| **Kimi** | 3,753 | 99% | Good — complete, clean formatting | **Tier 1** |
-| **Grok** | 3,751 | 99% | Good — complete, proper technical terms | **Tier 1** |
-| **Llama** | 3,748 | 99% | Good — complete, correct formatting | **Tier 1** |
-| **Mistral** | 3,742 | 99% | Good — complete | **Tier 1** |
-| **Opus** | 3,733 | 98% | Good — "Aaron Davis" (Kumavis real name), "DappSys," complete | **Tier 1** |
-| **Qwen** | 3,721 | 98% | Good — complete | **Tier 1** |
-| **DeepSeek** | 3,699 | 97% | Good — complete | **Tier 1** |
-| **ChatGPT** | 3,687 | 97% | Good — complete, proper formatting | **Tier 1** |
-| **MiniMax** | 2,593 | 68% | **TRUNCATED** — cuts off at [17:27], mid-sentence; only covers first ~68% of interview | **Tier 3** |
-| **GLM** | 14,479 | N/A | **UNUSABLE** — same chain-of-thought dump as AssemblyAI version | **Tier 4** |
+| Processor | Words | % of Max | Lines | Completeness | Tier |
+|-----------|-------|----------|-------|-------------|------|
+| **Gemini** | 3,800 | 100% | 320 | Complete (00:02 to 25:35) | **Tier 1** |
+| **Grok** | 3,751 | 99% | 198 | Complete (00:02 to 25:35) | **Tier 1** |
+| **Opus** | 3,733 | 98% | 198 | Complete (00:02 to 25:35) | **Tier 1** |
 
-**Key findings:**
-- WhisperX local produced more uniform results across processors (most at 97-100%) than AssemblyAI, likely because the raw input was already well-formatted with fine-grained speaker turns.
-- MiniMax is severely truncated — it stops at the 17:27 mark, missing the entire second half of the interview (Devcon 0/1 memories, launch day, EthereumJS architecture, eWASM discussion).
-- GLM again produces chain-of-thought reasoning instead of clean output.
-- The whisperx raw transcript uses "FDev" which some processors correctly resolved to "ETH Dev" or "EF."
+### WhisperX Local Processor Details
+
+**Gemini (Tier 1):** Complete coverage. Uses "EthereumJS-TX" formatting. Correct "AlethZero" from raw. Proper "Plan 9" reference. Identifies `cd` commands in backticks for the filesystem interface discussion. Speaker attribution throughout is correct. Uses "Kumavis" for the contributor. Good paragraph breaks for readability.
+
+**Grok (Tier 1):** Complete coverage. Notable error: renders "Joseph Chow" as "Joseph Lubin" throughout -- this is a significant factual mistake. Joseph Chow is the correct early EthereumJS contributor who later built BTC Relay; Joseph Lubin is the ConsenSys founder, an entirely different person. Otherwise clean and well-formatted. Uses "Beasy"/"Bexay" phonetic renderings. "kumavis" rendered in lowercase. "plan nine" rather than "Plan 9."
+
+**Opus (Tier 1):** Complete coverage. Correctly uses "Aaron Davis" (Kumavis's real name) throughout, including for the MetaMask connection. Correct "Ethereum.js" formatting. "Taylor" is used where other transcripts say "Texture" -- this appears to be a name interpretation from the raw whisperx transcript. "DappSys" for the community group. Clean conversational formatting.
+
+**Quality comparison:** All complete. Gemini has best technical formatting. Grok has the critical "Joseph Lubin" error. Opus uses real names ("Aaron Davis") where possible. The whisperx local base produced slightly shorter outputs across the board compared to AssemblyAI.
 
 ---
 
 ## 4. AI Processor Comparison (WhisperX-cloud base)
 
-Max word count (excluding GLM anomaly): 3,862 (Opus)
+Three processor outputs available. Max word count: 3,862 (Opus).
 
-| Processor | Words | % of Max | Quality | Tier |
-|-----------|-------|----------|---------|------|
-| **Opus** | 3,862 | 100% | Good — complete, proper names, clean formatting, speaker labels correctly assigned despite poor input diarization | **Tier 1** |
-| **Kimi** | 3,830 | 99% | Good — complete | **Tier 1** |
-| **Gemini** | 3,783 | 98% | Good — complete | **Tier 1** |
-| **Llama** | 3,632 | 94% | Good — complete | **Tier 1** |
-| **Grok** | 3,609 | 93% | Good — complete | **Tier 1** |
-| **MiniMax** | 3,606 | 93% | Good — complete (unlike the whisperx local version, this one is not truncated) | **Tier 1** |
-| **DeepSeek** | 3,558 | 92% | Good — complete | **Tier 1** |
-| **ChatGPT** | 3,553 | 92% | Good — complete | **Tier 1** |
-| **Mistral** | 3,536 | 92% | Good — complete | **Tier 1** |
-| **Qwen** | 3,510 | 91% | Good — complete | **Tier 1** |
-| **GLM** | 11,056 | N/A | **UNUSABLE** — same chain-of-thought reasoning dump | **Tier 4** |
+| Processor | Words | % of Max | Lines | Completeness | Tier |
+|-----------|-------|----------|-------|-------------|------|
+| **Opus** | 3,862 | 100% | 326 | Complete (00:02 to 22:38) | **Tier 1** |
+| **Gemini** | 3,783 | 98% | 244 | Complete (00:02 to 25:36) | **Tier 1** |
+| **Grok** | 3,609 | 93% | 52 | Complete (00:02 to 25:35) | **Tier 2** |
 
-**Key findings:**
-- Despite WhisperX-cloud's poor diarization (long merged paragraphs, swapped speakers), most processors handled it reasonably well, producing complete transcripts.
-- However, the poor input diarization means the speaker attribution in these outputs is less reliable than those from AssemblyAI or WhisperX local bases.
-- GLM again fails identically across all three transcriber bases — producing reasoning output instead of a transcript.
-- WhisperX-cloud outputs tend to be slightly shorter overall than AssemblyAI outputs.
+### WhisperX-cloud Processor Details
+
+**Opus (Tier 1):** Despite the poor input diarization, Opus successfully re-diarized the conversation into proper speaker turns with fine-grained timestamps. Complete coverage. Correctly identifies "AlethZero," "EthDev," "Kumavis." Speaker labels are correctly assigned (correcting the swapped input). The output has 326 lines -- significantly more than the 54-line input -- demonstrating substantial structural reconstruction. Final timestamp is 22:38 rather than ~25:35; this is because the whisperx-cloud input's timestamps are compressed/inaccurate compared to the actual audio duration, but all content is present through the closing exchange.
+
+**Gemini (Tier 1):** Also successfully re-diarized from the coarse input. Complete coverage with all topics present. Uses `node-ethereum` and `ethereumjs-tx` in backticks. Proper formatting. Speaker turns are reconstructed into natural dialogue with appropriate attribution. 244 lines, less granular than Opus but still well-structured. Handles the poor input well.
+
+**Grok (Tier 2):** Complete content is present but formatting is significantly degraded. Only 52 lines total -- Grok largely preserved the coarse paragraph structure of the input rather than re-diarizing. Long blocks of merged dialogue remain, making it difficult to follow the conversation flow. Speaker attribution within paragraphs is ambiguous. Uses "Aaron Davis" where appropriate. Content coverage is complete (final "thank you, Bob" is present), but the reading experience is significantly worse than the other processors.
+
+**Quality comparison:** Opus handled the poor input best, performing substantial structural reconstruction. Gemini also did well. Grok's output suffers from preserving the coarse input structure, resulting in long merged paragraphs with poor readability.
 
 ---
 
-## 5. Consensus Pipeline
+## 5. Cross-Transcriber Comparison
 
-**Status:** No `*_final.md` file exists. The consensus pipeline has not been run for this episode.
-
----
-
-## 6. Cross-Transcriber Comparison
-
-Side-by-side word counts for the same processor across different transcriber bases (excluding GLM):
+Side-by-side word counts for each processor across all three transcriber bases:
 
 | Processor | AssemblyAI | WhisperX local | WhisperX-cloud |
 |-----------|-----------|----------------|---------------|
-| ChatGPT | 3,702 | 3,687 | 3,553 |
-| DeepSeek | 3,883 | 3,699 | 3,558 |
-| Gemini | 4,093 | 3,800 | 3,783 |
-| Grok | 4,074 | 3,751 | 3,609 |
-| Kimi | 3,689 | 3,753 | 3,830 |
-| Llama | 4,101 | 3,748 | 3,632 |
-| MiniMax | 4,089 | **2,593** | 3,606 |
-| Mistral | 4,026 | 3,742 | 3,536 |
-| Opus | 3,850 | 3,733 | 3,862 |
-| Qwen | 3,869 | 3,721 | 3,510 |
+| **Gemini** | 4,093 | 3,800 | 3,783 |
+| **Grok** | 4,074 | 3,751 | 3,609 |
+| **Opus** | 3,850 | 3,733 | 3,862 |
 
 **Observations:**
-- AssemblyAI consistently produces the longest processor outputs (avg ~3,938 excluding GLM and MiniMax anomaly), followed by WhisperX-cloud (avg ~3,648) and WhisperX local (avg ~3,704 excluding MiniMax truncation).
-- MiniMax's WhisperX local output is the only severe truncation among normal processors.
-- Processor quality is generally consistent across transcriber bases for most models.
-- Kimi and Opus slightly favored WhisperX-cloud input, while Gemini, Grok, and Llama favored AssemblyAI.
+- AssemblyAI consistently produces the longest Gemini and Grok outputs, reflecting its more granular raw input.
+- Opus is the only processor where the WhisperX-cloud output is longer than AssemblyAI -- this is likely because Opus performed more structural reconstruction, adding speaker labels and turn breaks that inflate word count.
+- Gemini is the most consistent across transcriber bases (range: 310 words / 8%).
+- Grok shows the largest variation (range: 465 words / 11%) and is most sensitive to input quality.
+- Opus is remarkably stable (range: 129 words / 3%).
 
 ---
 
-## 7. Specific Quality Issues
+## 6. Specific Quality Issues
 
-### Name Rendering
-The guest's surname "Becze" (pronounced approximately "Beck-say" or "Bee-see") is rendered differently across outputs:
-- **Correct:** Gemini (assemblyai, whisperx), Grok (assemblyai), Opus, Mistral, Qwen — use "Becze"
-- **Phonetic approximations:** ChatGPT ("Bixby"/"Baxter"), DeepSeek ("Busey"/"Baxter"), Kimi ("Baxter")
-- **Critical error:** MiniMax (assemblyai) — identifies guest as "Martin Holst Swende" (entirely wrong person)
+### Name Rendering: "Martin Becze"
+The guest's surname "Becze" (pronounced approximately "Beck-say" or "Bee-see") is rendered differently:
+- **Correct:** All Opus outputs, all Gemini outputs, all Grok outputs use "Becze"
+- The raw transcripts produce "Baxter," "Bexer," "Bexay," "Beasy" -- all processors correctly resolve this
 
 ### "Joseph Chow" vs "Joseph Lubin"
 - The transcript references "Joseph Chow," an early EthereumJS contributor
-- DeepSeek systematically replaces this with "Joseph Lubin" — a significant factual error
-- Most other processors correctly retain "Joseph Chow"
+- **Grok (whisperx)** systematically replaces "Joseph Chow" with "Joseph Lubin" -- a significant factual error
+- Joseph Chow later built BTC Relay; Joseph Lubin is the ConsenSys founder -- entirely different people
+- All other outputs correctly retain "Joseph Chow"
 
 ### "Kumavis" / Aaron Davis
-- The raw transcript contains "Kamavis"/"Kamavas"/"Movis Davis" etc.
-- Opus and Mistral correctly identify this as "Aaron Davis" (Kumavis's real name)
-- ChatGPT and others use "Kumavis" (the better-known handle)
-- MiniMax uses "Mav Davis" — partially correct
+The raw transcript contains garbled versions: "Kamavis," "Mavis Davis," "Kumavis Davis"
+- Opus outputs use "Kumavis" (well-known handle) or "Aaron Davis" (real name) -- both valid
+- Gemini uses "Aaron Davis" on assemblyai base, "Kumavis" elsewhere
+- Grok uses "Kumavis Davis" (blend) or "Aaron Davis"
+
+### "Texture" / Taylor
+The person referenced around the Skype water cooler discussion:
+- AssemblyAI-based outputs use "Texture" (appears to be the person's handle)
+- WhisperX-based outputs from Opus and Grok render this as "Taylor" -- possibly a misrecognition from the raw transcriber
+- Gemini (whisperx-cloud) uses "Texture" correctly
 
 ### "Codius" (Ripple's VM project)
-- Gemini and Grok correctly identify "Codius"
-- Others leave it as "Codex" or "Code Codex"
+- Gemini and Grok (assemblyai) correctly identify "Codius"
+- Others leave it as "Codex" or similar approximations
+- This is a minor detail but demonstrates Ethereum ecosystem knowledge
+
+### "AlethZero" / "PoC 0"
+- Gemini correctly renders "AlethZero" across bases
+- Opus uses "PoC 0" (Proof of Concept Zero) -- different but valid reference
+- Grok uses "Aleth 0" -- partially corrected
+
+---
+
+## 7. Tier Summary
+
+| Tier | Output | Notes |
+|------|--------|-------|
+| **Tier 1** | assemblyai_gemini (4,093w) | Best technical corrections, complete, excellent formatting |
+| **Tier 1** | assemblyai_grok (4,074w) | Most faithful to speech, complete, clean |
+| **Tier 1** | assemblyai_opus (3,850w) | Cleanest prose, slightly tightened, complete |
+| **Tier 1** | whisperx_gemini (3,800w) | Complete, good formatting, correct terms |
+| **Tier 1** | whisperx_opus (3,733w) | Complete, uses real names, clean |
+| **Tier 1** | whisperx-cloud_opus (3,862w) | Best structural reconstruction from poor input |
+| **Tier 1** | whisperx-cloud_gemini (3,783w) | Good reconstruction, complete |
+| **Tier 1** | whisperx_grok (3,751w) | Complete but has "Joseph Lubin" error |
+| **Tier 2** | whisperx-cloud_grok (3,609w) | Complete content but poor formatting (52 lines, merged paragraphs) |
+
+**Note on whisperx_grok:** While complete and generally well-formatted, the systematic "Joseph Lubin" error (replacing "Joseph Chow" throughout) is a significant factual inaccuracy. This keeps it at Tier 1 by the completeness metric but it would need correction before use.
 
 ---
 
 ## 8. Recommendations
 
-1. **Best single output:** `episode012-martin-becze_assemblyai_chatgpt.md` — polished prose, correct names ("Kumavis," "AlethZero," "a16z"), complete coverage, excellent formatting with proper quotation marks and em-dashes.
+1. **Best single output:** `episode012-martin-becze_assemblyai_opus.md` -- cleanest prose, correct names throughout ("Kumavis," "PoC 0," "Becze"), excellent formatting, complete coverage with natural dialogue flow.
 
-2. **Runner-up outputs:** `assemblyai_opus`, `assemblyai_gemini`, `assemblyai_grok` — all Tier 1 with different strengths (Opus has cleanest prose, Gemini has best technical term correction, Grok has best formatting).
+2. **Runner-up outputs:** `assemblyai_gemini` (best technical term correction, "Codius," "AlethZero," backticked code references) and `assemblyai_grok` (most faithful to original speech, complete, clean formatting).
 
-3. **Remove or flag GLM outputs:** All three GLM files (assemblyai, whisperx, whisperx-cloud) contain the model's chain-of-thought reasoning rather than a clean transcript. These are 27,771, 14,479, and 11,056 words of analysis notes and should be flagged as unusable.
+3. **Best transcriber base:** AssemblyAI produces the best downstream results. All three AssemblyAI-based outputs are Tier 1 with no critical errors.
 
-4. **Remove or flag whisperx_minimax:** This output is truncated at 68% (stops at 17:27), missing the entire second half of the interview.
+4. **Grok whisperx error:** The systematic "Joseph Lubin" substitution in `whisperx_grok` needs correction if that output is used in any consensus process.
 
-5. **Run consensus pipeline:** No final output exists. The best candidates for consensus input would be the AssemblyAI-based outputs from ChatGPT, Opus, Gemini, and Grok.
+5. **WhisperX-cloud limitations:** While Opus and Gemini successfully reconstructed the poorly diarized input, these outputs should be treated as secondary to AssemblyAI-based outputs due to potential speaker attribution uncertainties.
 
-6. **Name correction needed in final:** The guest's name should be standardized as "Martin Becze" in any final output. The pronunciation discussion in the opening should be preserved but the header/metadata should use the correct spelling.
+6. **"Texture" vs "Taylor" discrepancy:** The WhisperX-based transcripts render this name as "Taylor" while AssemblyAI-based ones use "Texture." This should be investigated against the original audio to determine the correct rendering.
 
-7. **DeepSeek assemblyai output:** Flag the "Joseph Lubin" error — this is a critical factual inaccuracy that would need correction in any consensus process.
+7. **Consensus candidates:** For a consensus pipeline, the three AssemblyAI-based outputs (opus, gemini, grok) would be the strongest inputs, providing complementary strengths in prose quality, technical accuracy, and speech fidelity.

--- a/outputs/episode013-alex-van-de-sande/episode013-alex-van-de-sande_quality_assessment.md
+++ b/outputs/episode013-alex-van-de-sande/episode013-alex-van-de-sande_quality_assessment.md
@@ -1,155 +1,211 @@
-# Episode 013 (Alex Van de Sande) — Quality Assessment Report
+# Episode 013 (Alex Van de Sande) -- Quality Assessment Report
 
-**Episode:** Early Days of Ethereum — Episode 013, Alex Van de Sande (avsa)
-**Speakers:** Bob Summerwill (Host, SPEAKER_00), Alex Van de Sande (Guest, SPEAKER_01)
+**Episode:** Early Days of Ethereum -- Episode 013, Alex Van de Sande (avsa)
+**Speakers:** Bob Summerwill (Host), Alex Van de Sande (Guest)
 **Duration:** ~30 minutes
-**Assessment Date:** 2026-02-22
+**Assessment Date:** 2026-02-23
 
 ---
 
-## 1. Transcriber Comparison
+## 1. Transcriber Comparison (Raw Intermediates)
 
-Three transcriber sources were evaluated from intermediates:
+Three transcriber sources were evaluated from `intermediates/episode013-alex-van-de-sande/`:
 
-| Transcriber | Word Count | Diarization | Speaker Separation | Key Issues |
+| Transcriber | Word Count | Lines | Diarization Quality | Speaker Separation |
 |---|---|---|---|---|
-| **WhisperX (local)** | 4,544 | Good — two speakers correctly identified | Clean turn-by-turn separation | "Fiora" for Infura; "eaters" for Ether; "depth" for dapp; minor name misspellings |
-| **WhisperX-Cloud** | 4,535 | Poor — speakers frequently swapped | Speakers merged within paragraphs; multi-speaker blocks | Speaker labels 00/01 often inverted; long blocks attributed to wrong speaker; trailing content merged |
-| **AssemblyAI** | 4,656 | Good — two speakers correctly identified | Clean turn-by-turn separation with more granular timestamps | "neomist" for "know Mist"; "myth" for Mist; "left Terrace" for Lefteris; "Rotkey/ROTKitty" for Rotki |
+| **AssemblyAI** | 4,656 | 71 | Good -- two speakers correctly identified as SPEAKER_00 (host) and SPEAKER_01 (guest) | Clean turn-by-turn with granular timestamps; brief interjections get own blocks (e.g., "Yes, go for it" at [01:58]) |
+| **WhisperX (local)** | 4,544 | 63 | Good -- two speakers correctly identified but INVERTED: SPEAKER_01 is host (Bob), SPEAKER_00 is guest (Alex) | Clean turn-by-turn separation; fewer timestamp breaks than AssemblyAI |
+| **WhisperX-Cloud** | 4,535 | 45 | Poor -- speakers frequently swapped and merged | Multiple speakers' content collapsed into single blocks; trailing content often merged with wrong speaker; last 5 minutes severely degraded |
 
-**Summary:** WhisperX (local) and AssemblyAI both produce good diarization with clear two-speaker separation. WhisperX-Cloud has significantly worse diarization — speakers are frequently swapped and multiple speakers' speech is merged into single blocks, especially in the latter half. All three have roughly equivalent word counts, suggesting similar completeness of raw transcription. AssemblyAI captures slightly more content (4,656 words vs ~4,540 for WhisperX variants). AssemblyAI provides more granular timestamps with separate entries for brief interjections (e.g., "And how did that happen? Sorry." gets its own timestamp block).
+### Key Transcriber Issues
+
+**AssemblyAI:**
+- "neomist" for "knew Mist" (line 3)
+- "myth" for "Mist" (line 7)
+- "left Terrace" for "Lefteris" (line 21)
+- "Rotkey"/"ROTKitty" for "Rotki" (lines 21-23)
+- "eaters" for "Ether(s)" (lines 36-39)
+- "depth" for "dapp" (multiple occurrences)
+- "Fiora" for "Infura" not present -- correctly transcribed context
+- Captures opening name pronunciation attempt ("Van der Sander...")
+- More granular timestamps with separate entries for brief responses
+
+**WhisperX (local):**
+- Speaker labels inverted vs AssemblyAI (SPEAKER_01 = Bob, SPEAKER_00 = Alex)
+- "Fiora" for "Infura" (line 13)
+- "eaters" for "Ether(s)" (line 31)
+- "WebTree" for "Web3" (lines 7, 11)
+- "GEF team" for "Geth team" (line 35)
+- Misses opening name pronunciation exchange (starts at "Okay, volume's good?")
+- "VNS" for "ENS" (line 47)
+
+**WhisperX-Cloud:**
+- Worst diarization of the three -- speakers frequently merged into single blocks
+- Opening lines collapse both speakers into SPEAKER_00
+- From ~18:00 onward, multiple speakers' dialogue merged into single paragraphs
+- Final section (29:25 onward) collapses both speakers into alternating fragments
+- "Fiora" for "Infura" (line 9)
+- "Rottke"/"RotKiddy" for "Rotki" (lines 13-15)
+- "stooge" for "stool" (line 7)
+- Same "WebTree" issue as WhisperX local
+
+**Summary:** AssemblyAI and WhisperX (local) both produce good diarization with clear two-speaker separation. AssemblyAI captures the most content (4,656 words) and provides the most granular timestamps. WhisperX-Cloud has significantly worse diarization, with speakers frequently swapped and merged, especially in the latter half of the conversation. All three sources have roughly equivalent word counts, suggesting similar raw transcription completeness.
 
 ---
 
-## 2. AI Processor Comparison — AssemblyAI Base
+## 2. AI Processor Comparison -- AssemblyAI Base
 
-| Processor | Words | Tier | Name Corrections | Technical Terms | Prose Quality | Key Issues |
-|---|---|---|---|---|---|---|
-| **Opus** | 4,603 | Tier 1 | Summerwill, AlethZero, Christoph Jentzsch, Rotkey (not corrected), Infura | Strong; three-legged stool, Web3, dapp store, ENS, Swarm, Whisper, Waku | Excellent; faithful verbatim with clean punctuation | "Left Terrace" not corrected to Lefteris; "Rotkey" left uncorrected; "depth node" left as-is |
-| **ChatGPT** | 4,378 | Tier 1 | Summerwill, AlethZero, Christoph Jentzsch, Lefteris, Rotki, Infura | Excellent; dapp store with eth symbol, three-legged stool, em-dashes for flow | Best prose quality; excellent paragraph breaks; clean formatting with dashes and quotes | "Peanuts" left as-is (possibly correct app name); "a four" not corrected |
-| **DeepSeek** | 4,508 | Tier 1 | Summerwill, AlethZero, Christoph Jentzsch, Rotki, Geth (for Infura?), Lefteris | Strong; three-legged stool, AlethOne, ENS | Good; clean but minimal editorial intervention | "Geth" substituted for what was likely "Infura" or "Frontier"; "Depth Store" left; "a four" left |
-| **Gemini** | 4,633 | Tier 1 | Summerwill, AlethZero, Christoph Jentzsch, Rotki, Infura, AlethOne, Lefteris, Viktor | Excellent; Name Registry System, EtherScript, DApp, Peanut, on-chain | Very good; clean formatting with paragraph breaks | "Depth Store" partially left; "a four" not corrected; "dapp node" for "depth node" |
-| **Grok** | 4,593 | Tier 1 | Summerwill, Rotki, Infura, Lefteris | Good; three-legged stool, Devconnect, trust-minimized | Good; faithful to source | "desktop node" for "depth node" (reasonable); "fork" for garbled word; some over-correction |
-| **Kimi** | 4,655 | Tier 1 | Summerwill, Rotki, AlethZero, Christoph Jentzsch, Infura | Good; three-legged stool, dapp store, Devcon 0 | Good; clean with em-dash usage and quotes | Code block wrapper at start; "four-core machine" for garbled word; "Luke Torsani" for Lefteris |
-| **Llama** | 4,642 | Tier 1 | Summerwill, Radicle (wrong!), Infura, Lefteris | Acceptable; three-legged stool | Good; faithful | "Radicle" substituted for Rotki (incorrect hallucination); "a four" left; "depth node" left |
-| **MiniMax** | 4,658 | Tier 1 | Summerwill, AlethZero, Christoph Jentzsch, Infura, Lefteris | Good; three-legged stool, Vitalik Buterin expanded | Good; clean formatting | "Rocket" for Rotki (incorrect); "a four" left; "depth node" left |
-| **Mistral** | 4,636 | Tier 1 | Summerwill, Infura, Lefteris | Acceptable; three-legged stool | Good; some improved punctuation | "Rocket" for Rotki (incorrect); "a four" left; "depth node" left |
-| **Qwen** | 4,513 | Tier 1 | Bob Samuel (NOT corrected), Rotky (NOT corrected) | Minimal corrections; "Fura" left as-is | Weakest in this group; essentially a pass-through of raw transcript | "neomist" left; "Myst/myth" left; "left Terrace" left; "Fura" for Infura left; lowest intervention |
-| **GLM** | 11,231 | Tier 4 | N/A (output corrupted) | N/A | **Unusable** — first ~200 lines are exposed chain-of-thought reasoning notes | Model leaked its internal reasoning process before outputting the actual transcript; final transcript portion (lines 204-272) is actually good quality with many correct fixes |
+| Processor | Words | Lines | % of Max | Tier | Rating |
+|---|---|---|---|---|---|
+| **Opus** | 4,603 | 69 | 99.4% | Tier 1 | Excellent |
+| **Gemini** | 4,633 | 87 | 100% | Tier 1 | Excellent |
+| **Grok** | 4,593 | 69 | 99.1% | Tier 1 | Excellent |
+
+### AssemblyAI + Opus (4,603 words)
+- **Completeness:** Full transcript from [00:05] to [30:27], all content preserved
+- **Name corrections:** "Bob Summerwill" (corrected from "Bob Samuel"), "AlethZero", "Christoph Jentzsch", "avsa.eth.xyz", "Etherscript", "DevCon Zero"
+- **Technical terms:** Correctly renders "three-legged stool", "dapp store", "dapps", "Swarm", "Whisper", "Waku", "Nimbus", "ENS", "Mutan"
+- **Speaker attribution:** Maintains original AssemblyAI speaker labels accurately
+- **Issues:** "Left Terrace" not corrected to "Lefteris"; "Rotkey" not corrected to "Rotki"; "depth node" left as-is; some domain terms unclear ("Ethereum if" for "ethereum.eth")
+- **Formatting:** Clean single-paragraph-per-turn format with consistent timestamps
+
+### AssemblyAI + Gemini (4,633 words)
+- **Completeness:** Full transcript from [00:05] to [30:27], all content preserved
+- **Name corrections:** "Bob Summerwill" (from "Bob Samuel"), "AlethZero", "AlethOne", "Christoph Jentzsch", "Avsa.eth.xyz"
+- **Technical terms:** Correctly renders "three-legged stool", "Dapp Store", "Name Registry System", "Swarm", "Whisper", "Waku", "Nimbus", "ENS", "Mutan", "EtherScript"
+- **Speaker attribution:** Maintains original AssemblyAI labels
+- **Issues:** "an amuse" for "an amalgamate" at [02:00] -- introduced a new error; "Rotki" correctly rendered; "dapp node" for "DappNode"; breaks longer turns into multiple paragraphs (diverges from strict verbatim format)
+- **Formatting:** Multi-paragraph breaks within single speaker turns; slightly more editorial restructuring than Opus or Grok
+
+### AssemblyAI + Grok (4,593 words)
+- **Completeness:** Full transcript from [00:05] to [30:27], all content preserved
+- **Name corrections:** "Bob Summerwill", "AlethZero", "AlethOne", "Christoph Jentzsch", "Devconnect", "Devcon zero"
+- **Technical terms:** Correctly renders "three-legged stool", "Dapp Store", "dapps", "Swarm", "Whisper", "Waku", "Nimbus", "ENS", "Mutan", "Etherscript"
+- **Speaker attribution:** Maintains original AssemblyAI labels
+- **Issues:** "AVSA if XYZ" not corrected to "avsa.eth.xyz" at [30:12]; "Rotki" correctly rendered; "desktop node" for garbled audio (reasonable interpretation); "main register system" left uncorrected
+- **Formatting:** Clean single-paragraph-per-turn format; consistent with original structure
 
 ---
 
-## 3. AI Processor Comparison — WhisperX (local) Base
+## 3. AI Processor Comparison -- WhisperX (local) Base
 
-| Processor | Words | Tier | Key Observations |
+| Processor | Words | Lines | % of Max | Tier | Rating |
+|---|---|---|---|---|---|
+| **Opus** | 4,538 | 117 | 100% | Tier 1 | Excellent |
+| **Gemini** | 4,534 | 101 | 99.9% | Tier 1 | Excellent |
+| **Grok** | 4,541 | 61 | 100% | Tier 1 | Excellent |
+
+### WhisperX + Opus (4,538 words)
+- **Completeness:** Full transcript from [00:05] to [30:28], all content preserved
+- **Name corrections:** "Bob Summerwill", "AlethZero", "Aleph One", "Christoph Jentzsch", "Lefteris", "Rotki", "Infura" (corrected from "Fiora"), "DEVCON 0", "avsa.eth.xyz"
+- **Technical terms:** "three-legged stool", "dapp store", "dapps", "Ethereum.eth", ".eth", "Dappnode", "Geth", "Swarm", "Whisper", "Waku", "ENS"
+- **Speaker labels:** Preserves WhisperX inverted labels (SPEAKER_01 = Bob, SPEAKER_00 = Alex)
+- **Issues:** "DAO was supposed to be just a feature" -- introduces slight ambiguity vs "That was supposed to be"; "Ether Script" split into two words
+- **Formatting:** Excellent multi-paragraph formatting within longer turns; clean paragraph breaks improve readability significantly
+
+### WhisperX + Gemini (4,534 words)
+- **Completeness:** Full transcript from [00:05] to [30:28], all content preserved
+- **Name corrections:** "Bob Summerwill", "AlethZero", "AlethOne", "Christoph Jentzsch", "Lefteris", "Rotki", "Infura", "DevCon 0", "avsa.eth.xyz", "Geth team" (corrected from "GEF team")
+- **Technical terms:** "three-legged stool", "dapp store", "`ethereum.eth`" (code-formatted), "`.eth`", "DAppNode", "EtherScript", "Swarm", "Whisper", "Waku", "ENS"
+- **Speaker labels:** Preserves WhisperX inverted labels
+- **Issues:** Uses code formatting for ethereum.eth and .eth (editorial choice); uses em-dashes and quotation marks for Gavin's dialogue
+- **Formatting:** Multi-paragraph with tasteful editorial formatting; code-formatted domain names; quotation marks around direct speech -- highest prose quality of any output
+
+### WhisperX + Grok (4,541 words)
+- **Completeness:** Full transcript from [00:05] to [30:28], all content preserved
+- **Name corrections:** "Bob Summerwill", "AlethZero", "AlethOne", "Christoph Jentzsch", "Lefteris", "Rotki", "Infura", "Devcon 0", "avsa.eth.xyz", "Geth team"
+- **Technical terms:** "three-legged stool", "dapp store", "dapps", "Ethereum.ens" (incorrect), "Swarm", "Whisper", "Waku", "ENS"
+- **Speaker labels:** Preserves WhisperX inverted labels
+- **Issues:** "Ethereum.ens" instead of "ethereum.eth" -- incorrect domain correction; "desktop node" for DappNode; "multi thing" for unclear audio
+- **Formatting:** Single-paragraph-per-turn; clean but less readable than Opus or Gemini variants for this base
+
+---
+
+## 4. AI Processor Comparison -- WhisperX-Cloud Base
+
+| Processor | Words | Lines | % of Max | Tier | Rating |
+|---|---|---|---|---|---|
+| **Opus** | 4,551 | 75 | 100% | Tier 1 | Excellent |
+| **Gemini** | 4,521 | 129 | 99.3% | Tier 1 | Good-Excellent |
+| **Grok** | 4,450 | 43 | 97.8% | Tier 1 | Good |
+
+### WhisperX-Cloud + Opus (4,551 words)
+- **Completeness:** Full transcript from [00:05] to [30:32], all content preserved
+- **Name corrections:** "Bob Summerwill", "AlethZero", "Aleth One", "Christoph Jentzsch", "Lefteris", "Rotki", "Infura", "DevCon Zero", "avsa.eth.xyz"
+- **Technical terms:** "three-legged stooge" (left uncorrected from raw -- should be "stool"), "dapp store", "dappnode", "ETH", "Swarm", "Whisper", "Waku", "ENS"
+- **Diarization repair:** Successfully separates speakers into distinct turns despite poor source diarization; adds speaker break at [01:55] for "Yes, go for it"
+- **Issues:** "three-legged stooge" not corrected to "stool"; "multisig thing" -- interesting interpretation of unclear audio; overall excellent repair of source diarization problems
+- **Formatting:** Clean multi-paragraph format; good readability
+
+### WhisperX-Cloud + Gemini (4,521 words)
+- **Completeness:** Full transcript from [00:05] to [30:32] (final "Bye bye" present)
+- **Name corrections:** "Bob Summerwill", "AlethZero", "AlethOne", "Christoph Jentzsch", "Lefteris", "Rotki", "Infura" (though one instance of "within Infura" reads strangely), "DevCon Zero", "avsa.eth.xyz", "Geth team"
+- **Technical terms:** "three-legged stool" (corrected from "stooge"), "dapp store", "dapps", "ethereum.eth", ".eth", "Geth node", "ETH", "Swarm", "Whisper", "Waku", "ENS"
+- **Diarization repair:** Partial -- the opening section still merges Bob and Alex's speech under SPEAKER_00; later sections (from ~11:29) merge speaker transitions (Bob's and Alex's content in same block); end section still has merged speakers
+- **Issues:** Failed to fully repair diarization; from line 51 onward, SPEAKER_00 block at [11:29] contains both Bob's and Alex's speech; similar merges at [17:58] and [27:52]; closing lines fragmented across wrong speakers
+- **Formatting:** Multi-paragraph with heavy breaks; uses quotation marks and code formatting; em-dashes used for mid-sentence pauses
+
+### WhisperX-Cloud + Grok (4,450 words)
+- **Completeness:** Full transcript from [00:05] to final "Bye bye", all content present
+- **Name corrections:** "Bob Summerwill", "AlethZero", "AlethOne", "Christoph Jentzsch", "Lefteris", "Rotki", "Geth team"
+- **Technical terms:** "three-legged stooge" (not corrected), "dapp store", "dapps", "ethereum.eth", ".eth", "desktop node", "ETH", "Swarm", "Whisper", "Waku", "ENS"
+- **Diarization repair:** Minimal -- inherits most of the source's diarization problems; opening still merges speakers; from ~17:58, multiple speakers collapsed into single blocks; closing section completely merged
+- **Issues:** Least effective at repairing diarization issues from WhisperX-Cloud source; "Fiora" left as-is (not corrected to Infura) in one spot; "stooge" not corrected to "stool"; "movie thing" for unclear audio; "ether script" lowercase; lowest word count may indicate minor content loss
+- **Formatting:** Compact single-paragraph format with fewest lines (43); long dense blocks reduce readability
+
+---
+
+## 5. Cross-Transcriber Processor Summary
+
+### Word Count Matrix
+
+| Base / Processor | Opus | Gemini | Grok |
 |---|---|---|---|
-| **Opus** | 4,538 | Tier 1 | Good corrections: Summerwill, Mist, three-legged stool, Frontier, Swarm. Clean formatting. |
-| **ChatGPT** | 4,503 | Tier 1 | Good prose; corrections for Summerwill, Mist, Frontier. Consistent quality. |
-| **DeepSeek** | 4,539 | Tier 1 | Consistent with assemblyai base quality. |
-| **Gemini** | 4,534 | Tier 1 | Consistent quality with good name corrections. |
-| **Grok** | 4,541 | Tier 1 | Consistent quality. |
-| **Kimi** | 4,544 | Tier 1 | Consistent quality. |
-| **Llama** | 4,544 | Tier 1 | Consistent quality. |
-| **MiniMax** | 4,549 | Tier 1 | Consistent quality. |
-| **Mistral** | 4,569 | Tier 1 | Consistent quality. |
-| **Qwen** | 4,526 | Tier 1 | Consistent quality; slightly more conservative corrections. |
-| **GLM** | 934 | **Tier 4** | **Severely truncated** — only first ~8 minutes of content; cuts off mid-transcript. Unusable. |
+| **AssemblyAI** | 4,603 | 4,633 | 4,593 |
+| **WhisperX** | 4,538 | 4,534 | 4,541 |
+| **WhisperX-Cloud** | 4,551 | 4,521 | 4,450 |
 
----
+### Tier Matrix
 
-## 4. AI Processor Comparison — WhisperX-Cloud Base
-
-| Processor | Words | Tier | Key Observations |
+| Base / Processor | Opus | Gemini | Grok |
 |---|---|---|---|
-| **Opus** | 4,551 | Tier 1 | Good quality; inherits diarization errors from source but cleans text well. |
-| **ChatGPT** | 4,361 | Tier 1 | Good quality; slightly shorter due to filler word cleanup. |
-| **DeepSeek** | 4,535 | Tier 1 | Consistent quality. |
-| **Gemini** | 4,521 | Tier 1 | Consistent quality. |
-| **Grok** | 4,450 | Tier 1 | Consistent quality. |
-| **Kimi** | 2,862 | **Tier 3** | **Truncated** — stops at approximately the halfway point of the conversation. Missing the second half of content. |
-| **Llama** | 4,537 | Tier 1 | Consistent quality. |
-| **MiniMax** | 4,539 | Tier 1 | Consistent quality. |
-| **Mistral** | 4,547 | Tier 1 | Consistent quality. |
-| **Qwen** | 4,537 | Tier 1 | Consistent quality. |
-| **GLM** | 9,913 | **Tier 4** | **Unusable** — same problem as assemblyai_glm; first ~290 lines are exposed chain-of-thought reasoning notes with editing analysis, followed by actual transcript output. |
+| **AssemblyAI** | Tier 1 | Tier 1 | Tier 1 |
+| **WhisperX** | Tier 1 | Tier 1 | Tier 1 |
+| **WhisperX-Cloud** | Tier 1 | Tier 1 | Tier 1 |
+
+All 9 processor outputs are Tier 1 (complete, >90% of max word count). This episode is relatively short (~30 minutes) which helps all processors handle the full content without truncation.
 
 ---
 
-## 5. Consensus Pipeline
+## 6. Notable Observations
 
-**Status:** No `_final.md` file exists. The consensus pipeline has NOT been run for this episode.
+### Domain-Specific Term Challenges
+This episode contains several Ethereum ecosystem terms that challenge all processors:
+- **"Dappnode"** -- transcribed variously as "depth node", "dapp node", "desktop node", "tiny Geth node" across different outputs
+- **"ethereum.eth"** -- the original spoken domain is difficult; rendered as "Ethereum if", "Ethereum.eth", "Ethereum.ens" depending on processor
+- **"three-legged stool"** vs "stooge" -- WhisperX-Cloud raw had "stooge"; Gemini corrected it, Opus and Grok did not
+- **"Lefteris"** -- AssemblyAI transcribed as "left Terrace"; WhisperX variants got closer; Opus (AssemblyAI base) failed to correct, while all WhisperX-based processors corrected it
+- **"Rotki"** -- AssemblyAI transcribed as "Rotkey"/"ROTKitty"; WhisperX variants got closer; all WhisperX-based processors correctly rendered it
 
----
+### Speaker Label Consistency
+- AssemblyAI: SPEAKER_00 = Host (Bob), SPEAKER_01 = Guest (Alex) -- consistent across all processors
+- WhisperX: SPEAKER_01 = Host (Bob), SPEAKER_00 = Guest (Alex) -- inverted but consistent across all processors
+- WhisperX-Cloud: Speaker labels unreliable in source; Opus performed best at diarization repair, Gemini partial, Grok minimal
 
-## 6. Cross-Transcriber Comparison
+### Best Outputs by Category
+- **Best overall accuracy:** WhisperX + Gemini -- cleanest name corrections, proper code formatting for domain names, best prose quality, correct Geth/Jeff team identification
+- **Best diarization from poor source:** WhisperX-Cloud + Opus -- most successful at repairing the broken diarization
+- **Best raw fidelity:** AssemblyAI + Opus -- most faithful to original speech patterns with clean formatting
+- **Best readability:** WhisperX + Opus -- excellent paragraph breaking within long turns
 
-### Diarization Impact
-The WhisperX-Cloud base has fundamentally broken speaker diarization. In that intermediate, speakers 00 and 01 are frequently swapped or merged. For example, at [01:51], SPEAKER_01 delivers both Bob's and Alex's lines in a single block running from [01:51] through [03:43] — what should be separate turns. This persists throughout the file. **AI processors cannot fix broken diarization** — they faithfully preserve the incorrect speaker labels from the source. This means all WhisperX-Cloud outputs have systematically wrong speaker attribution.
-
-WhisperX (local) and AssemblyAI both have correct diarization. Between these two:
-- **AssemblyAI** provides more granular timestamp segmentation (e.g., short interjections like "And how did that happen?" get their own blocks)
-- **WhisperX (local)** tends to merge short interjections into longer speaker turns
-
-### Transcription Accuracy Differences
-Comparing the same passage across all three sources reveals minor differences in ASR errors:
-
-| Term (Actual) | WhisperX | WhisperX-Cloud | AssemblyAI |
-|---|---|---|---|
-| Infura/Frontier | "Fiora" | "Fiora" | "Fura" |
-| Rotki | "RockKey" | "Rottke" | "rotkey/ROTKitty" |
-| Lefteris | "Lefteris" (correct) | "Lefteris" (correct) | "left Terrace" |
-| "know Mist" | "knew Mist" | "knew Mist" | "neomist" |
-| "sync your node" | "think your node" | "think your node" | "think your node" |
-| AlethZero | "Aleph0" | "Aleph0" | "Aleph0" |
-| Ether/ETH | "eaters" | "eaters" | "eaters/Ethers" |
-| three-legged stool | "three-legged stooge" | "three-legged stooge" | "three legged stooge" |
-
-No single transcriber is consistently better across all terms. WhisperX gets "Lefteris" right while AssemblyAI garbles it to "left Terrace." AssemblyAI provides slightly better overall word accuracy for technical terms.
+### Recommended Best Transcript
+**WhisperX + Gemini** or **WhisperX + Opus** are the recommended best transcripts for this episode. Both correctly identify all major proper nouns (Lefteris, Rotki, Infura, Geth team, AlethZero, AlethOne), provide clean formatting, and maintain accurate speaker separation. Gemini edges ahead on prose polish and code formatting of domain names; Opus edges ahead on paragraph structure and faithful rendering.
 
 ---
 
-## 7. AI Processor Rankings
+## 7. Tier Definitions
 
-### Top Tier (Recommended)
-1. **ChatGPT** — Best prose quality across all bases; excellent paragraph segmentation; thoughtful em-dash and quotation mark usage; strong name corrections including Lefteris and Rotki; good balance of readability and fidelity
-2. **Gemini** — Most comprehensive name corrections (AlethZero, AlethOne, Christoph Jentzsch, Viktor, Lefteris, EtherScript); good technical vocabulary; clean formatting with paragraph breaks
-3. **Opus** — Most faithful to source text; excellent punctuation; strong technical corrections; conservative but accurate approach; missed "Lefteris" and "Rotki" corrections on AssemblyAI base
-4. **Grok** — Solid quality; good name corrections; "desktop node" is a reasonable interpretation of "depth node"
-
-### Mid Tier (Acceptable)
-5. **DeepSeek** — Good quality but occasionally makes wrong substitutions (Geth for Infura/Frontier)
-6. **Kimi** — Good quality overall; "Luke Torsani" for Lefteris is a notable hallucination; code block wrapper at start is a formatting issue
-7. **Mistral** — Decent quality; "Rocket" for Rotki is wrong
-8. **MiniMax** — Decent quality; "Rocket" for Rotki is wrong
-
-### Lower Tier (Issues)
-9. **Llama** — Substituted "Radicle" for Rotki, which is a hallucination of a different crypto project
-10. **Qwen** — Essentially a pass-through with minimal corrections; leaves many errors uncorrected including "Bob Samuel", "neomist", "Fura", "left Terrace"
-
-### Unusable
-11. **GLM** — Catastrophic failure across all three transcriber bases: exposed chain-of-thought reasoning (assemblyai, whisperx-cloud) or severely truncated output (whisperx). This model consistently fails to produce clean transcript output.
-
----
-
-## 8. Recommendations
-
-1. **Run consensus pipeline** — This episode has no `_final.md`. A consensus run should prioritize WhisperX (local) and AssemblyAI bases, excluding WhisperX-Cloud due to broken diarization.
-
-2. **Exclude WhisperX-Cloud outputs from consensus** — The diarization errors in the WhisperX-Cloud intermediate are systematic and uncorrectable by AI processors. All 11 outputs from this base have wrong speaker labels.
-
-3. **Exclude GLM outputs from all pipelines** — GLM consistently produces unusable output (chain-of-thought leakage or severe truncation). It should be blacklisted for this episode.
-
-4. **Exclude whisperx-cloud_kimi** — Truncated at roughly 60% of expected content. Not usable for consensus.
-
-5. **Best single outputs for reference:**
-   - `episode013-alex-van-de-sande_assemblyai_chatgpt.md` — Best overall prose quality and name correction
-   - `episode013-alex-van-de-sande_assemblyai_gemini.md` — Most comprehensive technical term correction
-   - `episode013-alex-van-de-sande_whisperx_opus.md` — Most faithful transcription with good corrections
-
-6. **Known uncorrected errors across most outputs:**
-   - "depth node" (should likely be "desktop node" or "DappNode")
-   - "a four" at [10:05] (garbled; likely "a full [node]" or similar)
-   - "Peanuts/Peanut" at [24:19] (app name — may be correct as-is, or could be "Peach")
-   - "moody thing" / "movie thing" (unclear original word; possibly "multi-sig" or a specific project name)
-
-7. **Speaker label note:** SPEAKER_00 is Bob Summerwill (host) and SPEAKER_01 is Alex Van de Sande (guest) in AssemblyAI and WhisperX-Cloud. In WhisperX (local), the labels are swapped: SPEAKER_01 is Bob and SPEAKER_00 is Alex. AI processors preserve these labels from their source.
+- **Tier 1:** Complete (>90% of max word count), excellent quality -- suitable for publication
+- **Tier 2:** Mostly complete (70-90%), good quality -- usable with minor review
+- **Tier 3:** Truncated (<50%) or significant issues -- needs re-processing
+- **Tier 4:** Unusable -- corrupt, severely truncated, or fundamentally broken

--- a/outputs/episode013-zsolt-felfoldi/episode013-zsolt-felfoldi_quality_assessment.md
+++ b/outputs/episode013-zsolt-felfoldi/episode013-zsolt-felfoldi_quality_assessment.md
@@ -1,130 +1,162 @@
-# Episode 013 (Zsolt Felfoldi) — Quality Assessment Report
+# Episode 013 (Zsolt Felföldi) — Quality Assessment Report
 
-## 1. Transcriber Comparison
+## 1. Transcriber Quality
 
-| Transcriber | Status | Quality | Lines | Notes |
-|-------------|--------|---------|-------|-------|
-| **WhisperX local** | **BROKEN** | Unusable | 166 | Entirely corrupted — repeated exclamation marks (`!!!!!!`) replacing all content |
-| **WhisperX-cloud** | Not available | N/A | — | No whisperx-cloud transcript exists for this episode |
-| **AssemblyAI** | Excellent | ~97% | 294 | Clean diarization, accurate technical terms, publication-ready |
+| Transcriber | Word Count | Lines | Status | Diarization | Notes |
+|-------------|-----------|-------|--------|-------------|-------|
+| **AssemblyAI** | 8,186 | 294 | Excellent | 2 speakers (SPEAKER_00, SPEAKER_01), clean | Accurate speech recognition, proper sentence structure, good technical terms |
+| **WhisperX local** | 254 | 166 | **CORRUPTED** | Structure present but content destroyed | Entirely replaced by repeated exclamation marks (`!!!!!!`) — no actual words transcribed |
 
-**Verdict:** AssemblyAI is the only usable transcriber for this episode. WhisperX local suffered the same complete corruption seen in episode012. No whisperx-cloud transcript was generated.
+**Transcriber Verdict:** AssemblyAI is the only usable transcriber for this episode. WhisperX local suffered catastrophic corruption — the diarization timestamps and speaker labels survived, but all speech content was replaced with strings of exclamation marks. This is the same corruption pattern seen in other episodes.
 
----
-
-## 2. AI Processor Comparison (AssemblyAI base)
-
-| Processor | Words | Completeness | Quality | Tier |
-|-----------|-------|-------------|---------|------|
-| **Kimi** | 8,185 | 100% | Excellent prose, complete | **Tier 1** |
-| **GLM** | 8,178 | 100% | Excellent, faithful to original | **Tier 1** |
-| **Grok** | 7,859 | 96% | Excellent formatting, no issues | **Tier 1** |
-| **GLM5** | 7,744 | 95% | Excellent quality, complete | **Tier 1** |
-| **ChatGPT** | 7,076 | 86% | Polished prose, professional presentation | Tier 2 |
-| **Opus** | 6,665 | 81% | High quality, faithful | Tier 2 |
-| **Gemini** | 6,597 | 81% | Clean formatting, good quality | Tier 2 |
-| **MiniMax** | 6,180 | 75% | Acceptable quality | Tier 2 |
-| **Llama** | 6,083 | 74% | Good within content, somewhat condensed | Tier 2 |
-| **DeepSeek** | 5,945 | 73% | Name errors ("Zolt Zelfeldi"), grammatical issues | Tier 3 |
-| **Qwen** | 5,684 | 69% | Condensed | Tier 3 |
-| **Mistral** | 5,196 | 63% | Short, limited value | Tier 3 |
-
-**Key finding:** Unlike episode012, no processor suffered severe truncation here. The spread is narrower (5,196–8,185 words). Kimi and GLM produced the longest and most complete outputs. DeepSeek stands out negatively for misspelling the guest's name.
-
-**Top 3 processors:** Kimi, GLM, Grok — all complete with excellent quality.
+**Note on WhisperX-cloud:** No whisperx-cloud intermediate file exists in the intermediates directory, yet whisperx-cloud processor outputs exist in the outputs directory. These appear to have been generated from a whisperx-cloud transcription that was processed but not retained as an intermediate. The whisperx-cloud outputs use 3 speakers (SPEAKER_01, SPEAKER_03, plus occasionally SPEAKER_00/SPEAKER_UNKNOWN), suggesting a different diarization model was used.
 
 ---
 
-## 3. AI Processor Comparison (WhisperX local base)
+## 2. AssemblyAI Transcriber — Detail
 
-All WhisperX-based processor outputs are **unusable** — the corrupted input produced garbage output:
-
-| Processor | Words | Status |
-|-----------|-------|--------|
-| Mistral | 1,958 | Mostly `[Unintelligible]` markers |
-| MiniMax | 1,261 | Mostly `[Unintelligible]` markers |
-| ChatGPT | 180 | `[Unintelligible]` throughout |
-| Gemini | 180 | `[Unintelligible]` throughout |
-| Opus | 180 | `[Unintelligible]` throughout |
-| Kimi | 122 | `[Unintelligible]` throughout |
-| Llama | 122 | `[Unintelligible]` throughout |
-| DeepSeek | 122 | `[Unintelligible]` throughout |
-| Qwen | 122 | `[Unintelligible]` throughout |
-| Grok | 6 | Empty/near-empty |
-| GLM5 | 6 | Empty/near-empty |
-
-These confirm the WhisperX local transcription was completely corrupted before any AI processing.
+The AssemblyAI transcript is high quality:
+- Clean 2-speaker diarization (SPEAKER_00 = interviewer, SPEAKER_01 = Zsolt Felföldi)
+- Accurate timestamps throughout the ~60-minute interview
+- Technical terminology is well-captured: Geth, devp2p, LES protocol, DHT, EIP-4444, Merkle Patricia trie, Verkle trees, JSON-RPC
+- Proper names are mostly correct in the raw output: "Zolt Felfeldy" (minor misspelling), Jeffrey Wilke (minor), Peter Szilagyi (close), Bas Van Kervel
+- Filler words preserved naturally; conversational flow is intact
+- No gaps, no missing segments, no corruption
 
 ---
 
-## 4. AI Processor Comparison (WhisperX-cloud base)
+## 3. AI Processor Quality — AssemblyAI Base (opus, gemini, grok only)
 
-| Processor | Words | Completeness | Quality | Tier |
-|-----------|-------|-------------|---------|------|
-| **Grok** | 8,600 | 100% | Excellent, most complete | **Tier 1** |
-| **Opus** | 7,919 | 92% | High quality, faithful | **Tier 1** |
-| **Gemini** | 7,320 | 85% | Clean formatting | Tier 2 |
-| **Llama** | 7,273 | 85% | Good quality | Tier 2 |
-| **GLM** | 7,138 | 83% | Very good | Tier 2 |
-| **ChatGPT** | 6,804 | 79% | Polished prose | Tier 2 |
-| **Kimi** | 6,736 | 78% | Good quality | Tier 2 |
-| **GLM5** | 6,666 | 77% | Good quality | Tier 2 |
-| **MiniMax** | 6,545 | 76% | Acceptable | Tier 2 |
-| **Mistral** | 5,894 | 69% | Condensed | Tier 3 |
-| **Qwen** | 5,409 | 63% | Short | Tier 3 |
-| **DeepSeek** | 1,483 | 17% | Severely truncated | **Tier 4** |
+| Processor | Word Count | Lines | Completeness | Tier |
+|-----------|-----------|-------|-------------|------|
+| **assemblyai_grok** | 7,859 | 290 | ~96% of max | **Tier 1** |
+| **assemblyai_opus** | 6,665 | 248 | ~81% of max | **Tier 2** |
+| **assemblyai_gemini** | 6,597 | 284 | ~81% of max | **Tier 2** |
 
-**Note:** WhisperX-cloud outputs are generally comparable to AssemblyAI. DeepSeek is the outlier — severely truncated at only 1,483 words (17% of max).
+### assemblyai_grok (Tier 1 — Complete, Excellent)
+- **Word count:** 7,859 (96% of max across all processors)
+- **Coverage:** Complete from [00:02] to [59:39], covers the entire interview
+- **Name handling:** Retains raw transcriber names without correction (e.g., "Zolt Felfeldy", "Danny", "Victor", "Peter Szilagyi", "Jeffrey Wilke")
+- **Formatting:** Clean markdown with bold speaker/timestamp labels, consistent spacing
+- **Content fidelity:** Very faithful to the raw transcriber output; minimal editorial cleanup; preserves conversational filler ("So", "But yeah", "you know") and natural speech patterns
+- **Diarization accuracy:** Correct speaker attribution throughout; one notable error at [24:17] where SPEAKER_00's lines about Viktor/Gav seeing talks are mis-attributed to SPEAKER_01
+- **Topic coverage:** Covers all major topics: background, Swarm, hiring story, Jeff Wilcke, ETH Labs/Quorum, DEVCON 1, Light Client/LES, Portal, statelessness, Verkle trees, Mist/MetaMask, Raiden, team culture
+- **Assessment:** Excellent completeness with minimal processing. The most verbatim output, preserving all content including asides and interruptions
+
+### assemblyai_opus (Tier 2 — Mostly Complete, Excellent Quality)
+- **Word count:** 6,665 (81% of max)
+- **Coverage:** Complete from [00:02] to [50:39], covering ~50 minutes of an ~60-minute interview
+- **Name handling:** Excellent corrections — "Zsolt Felföldi" (with proper Hungarian diacritics), "Dániel", "Viktor", "Péter Szilágyi", "Jeffrey Wilcke", "Bas van Kervel"
+- **Formatting:** Clean markdown, consistent bold speaker labels, well-structured paragraphs
+- **Content fidelity:** High quality editorial cleanup — removes verbal stumbles, tightens prose, but preserves meaning accurately
+- **Missing content:** Stops at [50:39] — missing the final ~9 minutes covering multi-client philosophy, team size discussion, EF growth, looking back/visions, and Raiden. This is a significant truncation
+- **Topic coverage:** Missing: multi-client ecosystem discussion, Geth team culture, EF growth from 30-40 to hundreds, Raiden/state channels
+- **Assessment:** The highest editorial quality of the three — proper diacritical marks on Hungarian names, clean prose, accurate technical content. However, the truncation at ~50 minutes is a notable gap
+
+### assemblyai_gemini (Tier 2 — Mostly Complete, Good Quality)
+- **Word count:** 6,597 (81% of max)
+- **Coverage:** Complete from [00:02] to [59:39], covers the entire interview
+- **Name handling:** Good corrections — "Zsolt Felföldi", "Dani" (without accent), "Viktor", "Péter Szilágyi", "Jeffrey Wilcke", "Bas van Kervel", "Lefteris Karapetsas" (full name added)
+- **Formatting:** Clean markdown, consistent structure with bold speaker labels
+- **Content fidelity:** Moderate editorial cleanup — smooths conversational speech, adds punctuation, tightens phrasing; occasionally over-edits natural speech into polished prose
+- **Completeness:** Despite lower word count, covers the full interview including the final sections on team culture, EF growth, and Raiden
+- **Notable issues:** At [48:53] the Raiden mention is lost — instead it shows "We had state channels, and then we had Plasma" which is an interpolation by the processor, not what was said in this part of the conversation. At [49:06]-[49:07] there's a brief interruption ("Hello"/"See you, sir"/"Great to see you") that appears to be a passerby, correctly preserved
+- **Assessment:** Good overall quality with full coverage. More aggressively summarized than Grok, achieving fewer words while still covering all topics. Name corrections are good but not as precise as Opus
 
 ---
 
-## 5. Cross-Transcriber Comparison
+## 4. AI Processor Quality — WhisperX Local Base (opus, gemini, grok only)
 
-Side-by-side word counts for the same processor across different transcriber bases:
+All WhisperX local-based outputs are **unusable** due to the corrupted source transcription:
 
-| Processor | AssemblyAI | WhisperX-cloud | WhisperX local |
-|-----------|-----------|----------------|---------------|
-| Grok | 7,859 | 8,600 | 6 |
-| Opus | 6,665 | 7,919 | 180 |
-| Kimi | 8,185 | 6,736 | 122 |
-| GLM | 8,178 | 7,138 | — |
-| ChatGPT | 7,076 | 6,804 | 180 |
-| Gemini | 6,597 | 7,320 | 180 |
-| GLM5 | 7,744 | 6,666 | 6 |
-| Llama | 6,083 | 7,273 | 122 |
-| MiniMax | 6,180 | 6,545 | 1,261 |
-| Mistral | 5,196 | 5,894 | 1,958 |
-| DeepSeek | 5,945 | 1,483 | 122 |
-| Qwen | 5,684 | 5,409 | 122 |
+| Processor | Word Count | Lines | Status |
+|-----------|-----------|-------|--------|
+| **whisperx_opus** | 180 | 116 | All `[inaudible]` markers — AI correctly identified corruption but could produce nothing |
+| **whisperx_gemini** | 180 | 116 | All `[inaudible]` markers — identical failure pattern |
+| **whisperx_grok** | 6 | 0 | Near-empty; essentially blank output |
+
+**Verdict:** All three processors correctly identified the corrupted input but could not recover any content. Opus and Gemini produced structured `[inaudible]` markers preserving timestamps. Grok produced essentially nothing. All are Tier 4 (Unusable).
+
+---
+
+## 5. AI Processor Quality — WhisperX-Cloud Base (opus, gemini, grok only)
+
+| Processor | Word Count | Lines | Completeness | Tier |
+|-----------|-----------|-------|-------------|------|
+| **whisperx-cloud_grok** | 8,600 | 158 | ~100% | **Tier 1** |
+| **whisperx-cloud_opus** | 7,919 | 192 | ~92% | **Tier 1** |
+| **whisperx-cloud_gemini** | 7,320 | 232 | ~85% | **Tier 2** |
+
+### whisperx-cloud_grok (Tier 1 — Complete, Excellent)
+- **Word count:** 8,600 — the highest across ALL processor/transcriber combinations
+- **Coverage:** Complete from [00:01] to [59:41], covers the entire interview
+- **Name handling:** Retains raw transcriber names with minimal correction: "Zolt Felföldi" (first name not fully corrected), "Danny", "Viktor", "Peter Szilágyi", "Jeffrey Wilcke"
+- **Diarization:** Uses 3 speakers (SPEAKER_01, SPEAKER_03, and SPEAKER_00/SPEAKER_UNKNOWN at end). Speaker assignment is sometimes incorrect — interviewer lines bleed into guest lines and vice versa, with mid-sentence speaker splits
+- **Formatting:** Fewer lines (158) but longer utterances — less paragraph breaking than AssemblyAI-based outputs. Many filler words and verbal stumbles preserved ("So so", "yeah yeah", "you know")
+- **Content fidelity:** Extremely faithful/verbatim — preserves all hesitations, repetitions, and natural speech patterns. The raw conversational quality is high
+- **Notable issues:** Final lines at [59:41] have artifact noise: "thank you you" / "you you" / "you you you you you" — typical end-of-recording artifacts
+- **Assessment:** Most complete transcript by word count. Very raw/verbatim style with less editorial polish but maximum content preservation. The diarization issues from the whisperx-cloud base (speaker splits) are somewhat distracting but content is intact
+
+### whisperx-cloud_opus (Tier 1 — Complete, Excellent Quality)
+- **Word count:** 7,919 (92% of max)
+- **Coverage:** Complete from [00:01] to [59:11], covers essentially the entire interview
+- **Name handling:** Mixed — uses "Zsolt Felföldi" with proper diacritics, "Danny" (no accent), "Viktor", "Peter Szilágyi" (with accent), "Jeffrey Wilcke"
+- **Diarization:** Uses SPEAKER_01 and SPEAKER_03. Better speaker separation than the Grok variant — fewer mid-sentence speaker splits, but some interviewer/guest merge issues remain
+- **Formatting:** Clean markdown, well-structured with good paragraph breaks (192 lines)
+- **Content fidelity:** Good balance of editorial cleanup and content preservation. Smooths verbal stumbles while keeping meaning. Some sections merge multiple speaker turns into single blocks
+- **Notable issues:** Some speaker label confusion inherent from the whisperx-cloud diarization (3 speaker labels for 2 actual speakers)
+- **Assessment:** High quality output with near-complete coverage. Not quite as editorially polished as the assemblyai_opus variant (which has better name diacritics), but covers significantly more content (7,919 vs 6,665 words) because it does not truncate
+
+### whisperx-cloud_gemini (Tier 2 — Mostly Complete, Good Quality)
+- **Word count:** 7,320 (85% of max)
+- **Coverage:** Complete from [00:01] to [59:41], covers the entire interview
+- **Name handling:** Good corrections — "Zsolt Felföldi", "Dani", "Viktor", "Péter Szilágyi", "Jeffrey Wilcke", "Lefteris Karapetsas"
+- **Diarization:** Handled the 3-speaker whisperx-cloud input well, maintaining proper attribution
+- **Formatting:** Clean markdown, 232 lines with good structure and paragraph breaking
+- **Content fidelity:** Moderate editorial cleanup, smoothing conversational speech; adds punctuation and light structural improvements; occasionally adds emphasis markers (exclamation points) not present in original speech
+- **Assessment:** Solid output covering the full interview. The editorial cleanup is more aggressive than Grok but achieves good readability
+
+---
+
+## 6. Cross-Transcriber Comparison (opus, gemini, grok only)
+
+| Processor | AssemblyAI Words | WhisperX-cloud Words | WhisperX Words |
+|-----------|-----------------|---------------------|----------------|
+| **Grok** | 7,859 | **8,600** | 6 |
+| **Opus** | 6,665 | **7,919** | 180 |
+| **Gemini** | 6,597 | **7,320** | 180 |
 
 **Observations:**
-- AssemblyAI and WhisperX-cloud produce comparable results for most processors
-- WhisperX-cloud Grok (8,600) is the single highest word count across all combinations
-- WhisperX local is completely unusable across the board
-- DeepSeek performs poorly on WhisperX-cloud (1,483 words) but reasonably on AssemblyAI (5,945)
+- WhisperX-cloud consistently produces higher word counts than AssemblyAI for all three processors (9-19% more words)
+- This is likely because the whisperx-cloud transcription preserves more verbal filler and repetitions that get carried through to the processed output
+- WhisperX local is completely unusable across all processors
+- The assemblyai_opus output is notably truncated (stops at 50:39) compared to the whisperx-cloud_opus output (reaches 59:11) — the whisperx-cloud base produced 19% more words
+- AssemblyAI provides better diarization (clean 2-speaker) vs. WhisperX-cloud (3 speakers for 2 actual people, with some speaker splits)
+- AssemblyAI base allows Opus to produce superior name corrections (Hungarian diacritics) even though the word count is lower
 
----
-
-## 6. Consensus Pipeline
-
-**Status:** Not run — no `*_final.md`, `*_ai_quality_assessment.json`, or word-level consensus files exist for this episode. Only Pipeline 1 (single-model post-processing) was run.
+### Diarization Quality Comparison
+- **AssemblyAI:** 2 speakers, clean separation, correct attribution throughout. No mid-sentence splits
+- **WhisperX-cloud:** 3 speakers (SPEAKER_01, SPEAKER_03, plus occasional SPEAKER_00/SPEAKER_UNKNOWN). Speaker splits occur within sentences, causing some interviewer/guest attribution confusion. However, overall content accuracy is maintained
+- **WhisperX local:** Diarization structure survived (timestamps and speaker labels are present) but all speech content was replaced with exclamation marks — completely unusable
 
 ---
 
 ## 7. Recommendations
 
-### Best transcriber+processor combinations
-1. **AssemblyAI + Kimi** (8,185 words) — most complete, excellent quality
-2. **AssemblyAI + GLM** (8,178 words) — equally complete, excellent quality
-3. **WhisperX-cloud + Grok** (8,600 words) — highest word count overall, excellent quality
-4. **AssemblyAI + Grok** (7,859 words) — reliable, well-formatted
+### Best outputs for this episode
+1. **whisperx-cloud_grok** (8,600 words, Tier 1) — Most complete by word count, very faithful/verbatim, but raw style and diarization issues
+2. **assemblyai_grok** (7,859 words, Tier 1) — Excellent completeness with clean diarization, faithful to source
+3. **whisperx-cloud_opus** (7,919 words, Tier 1) — Good editorial quality with near-complete coverage
+4. **assemblyai_gemini** (6,597 words, Tier 2) — Full coverage with good editorial cleanup, but more condensed
+5. **assemblyai_opus** (6,665 words, Tier 2) — Best editorial quality and name handling, but truncated at ~50 minutes (missing final ~9 minutes)
 
-### Processors to avoid
-- **DeepSeek** — misspells guest's name on AssemblyAI base, severely truncated on WhisperX-cloud
-- **Mistral** — consistently produces the shortest outputs
-- **Qwen** — consistently condensed
+### For publication
+- **If maximum completeness is priority:** Use `whisperx-cloud_grok` or `assemblyai_grok`
+- **If editorial quality is priority:** Use `assemblyai_opus` but note the truncation — the last ~9 minutes covering multi-client philosophy, EF growth, and Raiden discussion would need to be sourced from another output
+- **Best balance:** `whisperx-cloud_opus` offers near-complete coverage with good editorial quality
 
-### Next steps
-- The consensus pipeline (Phases 2-6) has not been run for this episode
-- WhisperX local should be regenerated or skipped entirely (corruption pattern matches episode012)
-- For publication, `assemblyai_kimi.md` or `assemblyai_glm.md` are the best available outputs
+### Issues to address
+- **assemblyai_opus truncation:** Missing content from [50:39] to [59:39] (~9 minutes) should be re-processed or supplemented
+- **WhisperX local corruption:** Should be regenerated or permanently skipped for this episode
+- **Name standardization:** Guest name appears as "Zolt Felfeldy" (raw), "Zsolt Felföldi" (opus), "Zsolt Felföldi" (gemini). The correct Hungarian spelling with diacritics is "Zsolt Felföldi"
+- **Speaker identification:** No output assigns actual names to speakers — all use SPEAKER_00/SPEAKER_01 or SPEAKER_01/SPEAKER_03 labels

--- a/outputs/quality_report.md
+++ b/outputs/quality_report.md
@@ -1,299 +1,407 @@
 # Overall Quality Report
 
-*Generated: 2026-02-22*
+*Generated: 2026-02-23*
 *Episodes assessed: 15*
+*Processors: opus, gemini, grok*
+*Transcribers: AssemblyAI, WhisperX (local), WhisperX-cloud*
 
 ## Summary
 
-Across 15 episodes spanning short interviews (~25 min) to long-form conversations (~112 min), clear and statistically robust patterns emerge. **AssemblyAI** is the only transcriber with a perfect 15/15 reliability record and is unanimously rated best in every episode. Among AI post-processors, **Opus** is the dominant performer — Tier 1 in 13 of 15 episodes on the AssemblyAI base, winning 11 of 15 "best output" recommendations. **Grok** and **Gemini** form a reliable core alongside Opus, all achieving Tier 1 in 11+ episodes.
+Across 15 episodes of the Early Days of Ethereum podcast, a total of 121 processor outputs were assessed (15 episodes x 3 transcribers x 3 processors, minus unavailable combinations). Of these, 99 achieved Tier 1 (complete, >90% of max word count), 13 achieved Tier 2 (mostly complete but condensed or poorly formatted), and 9 were Tier 4 (unusable due to corrupted WhisperX local transcriber bases in episodes 007, 012-Fabian, and 013-Zsolt). No Tier 3 outputs were produced. The overall Tier 1 rate for usable outputs is 88%.
 
-The most important finding is that **GLM is catastrophically broken** — it dumps chain-of-thought reasoning instead of producing a clean transcript in 10 of 15 episodes (Tier 4). This is a systematic instruction-following failure that makes it unsuitable for any production use. Five other processors (Mistral, Qwen, DeepSeek, Llama, MiniMax) consistently truncate on longer episodes, losing 35–75% of content due to output token limits.
+**AssemblyAI** is the clear winner among transcriber bases, producing the best diarization, highest word counts, and cleanest formatting across all 15 episodes. It never suffered corruption. WhisperX (local) is a solid secondary option when it works but suffered catastrophic corruption in 3 of 14 episodes (21% failure rate). WhisperX-cloud consistently produced the worst diarization, with severely merged speaker blocks that only Opus could reliably decompose.
 
-The consensus pipeline has **zero successes across 15 episodes**. The two episodes with final output (007 and 012-Fabian) both produced degraded or catastrophically corrupted results. The word-level voting algorithm cannot handle divergent AI model outputs. Single-model outputs (especially Opus) consistently outperform consensus merges.
+Among AI processors, **Opus** delivers the most consistent quality across all transcriber bases, with a unique ability to reconstruct speaker turns from poorly diarized input. It achieves Tier 1 in 97% of usable outputs and is the recommended primary processor for 13 of 15 episodes. **Grok** is the most faithful/verbatim processor with the highest word counts and a perfect Tier 1 record on the AssemblyAI base, but introduces factual name substitution errors and fails to decompose merged speaker blocks. **Gemini** excels at proper noun identification and name enrichment but suffers from aggressive condensation on longer episodes (dropping to 31-59% retention) and occasionally strips timestamps.
 
 ---
 
 ## 1. Transcriber Reliability
 
-| Transcriber | Working | Broken | Not Run | Reliability | Notes |
-|-------------|---------|--------|---------|-------------|-------|
-| **AssemblyAI** | **15** | 0 | 0 | **100%** | Unanimously rated best in every episode |
-| **WhisperX local** | 11 | 3 | 1 | 79% | 3 corruption events (ep007, ep012-Fab, ep013-Zsolt) |
-| **WhisperX-cloud** | 12 | 0 | 2 | 86%* | Working but worst diarization in 12/13 episodes |
+| Transcriber | Episodes Available | Fully Usable | Corrupted/Broken | Best Diarization Count | Avg Quality Grade |
+|---|---|---|---|---|---|
+| **AssemblyAI** | 15/15 | **15** (100%) | 0 | **15/15** | A |
+| **WhisperX (local)** | 14/15 | **11** (79%) | 3 (ep007, ep012-Fabian, ep013-Zsolt) | 0/15 | B- |
+| **WhisperX-cloud** | 14/15 | **14** (100%) | 0 | 0/15 | C+ |
 
-*WhisperX-cloud was not run for episodes 011 and 013-Zsolt.
+**Notes:**
+- Episode 011 (Ryan Taylor) only had AssemblyAI transcription; no WhisperX outputs existed.
+- WhisperX local corruption manifested as hallucinated "Thank you" loops (ep007: 93 words) or exclamation mark strings (ep012-Fabian: 405 words, ep013-Zsolt: 254 words).
+- WhisperX-cloud was never corrupted but consistently produced the worst diarization with merged multi-speaker blocks, sometimes collapsing 5+ minutes of dialogue into a single paragraph.
 
-### WhisperX Local Corruption Patterns
-- **Episode 007**: Hallucinated "Thank you" loops (every block repeats "Thank you")
-- **Episode 012 (Fabian)**: Entire output replaced with exclamation marks (`!!!!!!`)
-- **Episode 013 (Zsolt)**: Same exclamation mark corruption as ep012
+### Diarization Quality Summary
 
-### WhisperX-Cloud Diarization Issues
-When WhisperX-cloud works, it consistently produces the worst speaker separation — long merged paragraphs with multiple speakers collapsed into single blocks or speaker labels swapped. AI processors cannot reliably fix diarization errors inherited from the transcriber.
+| Transcriber | Avg Speakers Detected | Speaker Accuracy | Turn Granularity | Typical Issues |
+|---|---|---|---|---|
+| **AssemblyAI** | 2-4 (correct) | Excellent | Fine-grained (100-350+ turns) | Minor phonetic ASR errors on proper nouns |
+| **WhisperX (local)** | 3-5 (sometimes extra) | Good | Moderate (60-200 turns) | Occasionally merges short interjections; sometimes inverts speaker labels |
+| **WhisperX-cloud** | 3-7 (often wrong count) | Poor | Coarse (25-94 turns) | Massive multi-speaker blocks; speakers frequently merged; wall-of-text paragraphs |
 
-**Verdict:** AssemblyAI should be the default (and often only) transcriber. WhisperX local is a useful secondary source when it works but cannot be relied upon. WhisperX-cloud adds cost without adding quality.
+### Transcriber Verdict
+
+**AssemblyAI is the unambiguous primary transcriber.** It produced the best diarization in all 15 episodes, never suffered corruption, and consistently yielded the highest word counts. WhisperX (local) is a useful secondary source when it functions but its 21% corruption rate is a significant reliability concern. WhisperX-cloud should only be used as a tertiary source; its poor diarization degrades downstream processor output quality, particularly for Gemini and Grok which cannot decompose merged speaker blocks.
 
 ---
 
 ## 2. Processor Leaderboard (AssemblyAI base)
 
-Ranked by Tier 1 count across 15 episodes, then Tier 1+2 rate.
+Data compiled from all 15 episodes where AssemblyAI-based processor outputs exist. Episode 011 only has an Opus output.
 
-| Rank | Processor | T1 | T2 | T3 | T4 | T1+2 Rate | Best Output Wins | Consistency |
-|------|-----------|----|----|----|----|-----------|-----------------|-------------|
-| 1 | **Opus** | **13** | 1 | 0 | 0 | **100%** | **11/15** | Excellent |
-| 2 | **Grok** | **12** | 2 | 0 | 0 | **100%** | 0 | Excellent |
-| 3 | **Gemini** | **11** | 3 | 0 | 0 | **100%** | 0 | Excellent |
-| 4 | **ChatGPT** | 6 | 3 | 3 | 1 | 69% | 2/15 | Variable |
-| 5 | **Kimi** | 5 | 6 | 1 | 0 | 85% | 1/15 | Good |
-| 6 | DeepSeek | 3 | 4 | 5 | 1 | 54% | 0 | Mixed |
-| 7 | Llama | 3 | 2 | 5 | 3 | 38% | 0 | Poor |
-| 8 | Qwen | 3 | 2 | 8 | 1 | 36% | 0 | Poor |
-| 9 | MiniMax | 2 | 3 | 5 | 3 | 38% | 0 | Poor |
-| 10 | Mistral | 1 | 4 | 8 | 1 | 36% | 0 | Poor |
-| 11 | **GLM** | 1 | 2 | 3 | **10** | 20% | 0 | **Catastrophic** |
+| Processor | Tier 1 | Tier 2 | Tier 3 | Tier 4 | T1 Rate | Consistency |
+|---|---|---|---|---|---|---|
+| **Grok** | **14** | 0 | 0 | 0 | **100%** | Excellent |
+| **Opus** | 14 | 1 | 0 | 0 | **93%** | Excellent |
+| **Gemini** | 11 | 3 | 0 | 0 | **79%** | Good |
 
-### The Reliable Core: Opus, Grok, Gemini
+### Per-Episode Breakdown (AssemblyAI base)
 
-These three processors achieve Tier 1 or 2 on **every single episode** — a 100% reliability rate across 15 assessments. Among them:
+| Episode | Opus Words | Opus Tier | Gemini Words | Gemini Tier | Grok Words | Grok Tier |
+|---|---|---|---|---|---|---|
+| 001 | 18,802 | T1 | 16,009 | T2 | 17,855 | T1 |
+| 002 | 11,814 | T1 | 11,248 | T1 | 11,016 | T1 |
+| 003 (Bob) | 11,554 | T1 | 11,777 | T1 | 11,805 | T1 |
+| 004 (Taylor) | 10,256 | T1 | 10,261 | T1 | 10,082 | T1 |
+| 005 (Anthony) | 14,308 | T1 | 14,639 | T1 | 14,978 | T1 |
+| 006 (Christoph) | 14,828 | T1 | 15,145 | T1 | 14,955 | T1 |
+| 007 (Jacob) | 2,868 | T1 | 2,747 | T1 | 2,830 | T1 |
+| 008 (Michael) | 4,273 | T1 | 4,425 | T1 | 4,251 | T1 |
+| 009 (Amir) | 9,196 | T1 | 8,884 | T1 | 8,655 | T1 |
+| 010 (Viktor) | 10,896 | T1 | 11,497 | T1 | 10,909 | T1 |
+| 011 (Ryan) | 12,102 | T1 | -- | -- | -- | -- |
+| 012 (Fabian) | 18,837 | T1 | 11,175 | T2 | 18,474 | T1 |
+| 012 (Martin) | 3,850 | T1 | 4,093 | T1 | 4,074 | T1 |
+| 013 (Alex) | 4,603 | T1 | 4,633 | T1 | 4,593 | T1 |
+| 013 (Zsolt) | 6,665 | T2 | 6,597 | T2 | 7,859 | T1 |
 
-- **Opus** is the clear #1: 13 Tier 1 ratings, best prose polish, most accurate name corrections, and recommended as the best output in 11 of 15 episodes.
-- **Grok** is the most faithful reproducer — highest word retention, excellent formatting, 12 Tier 1 ratings.
-- **Gemini** has the strongest technical term corrections and clean formatting, with 11 Tier 1 ratings. Occasionally resets timestamps to 00:00 offset (ep005).
+### Analysis
 
-### The Middle Tier: ChatGPT, Kimi
+**Grok** achieves a perfect Tier 1 record across all 14 assessed episodes on the AssemblyAI base, making it the most reliable by tier count. It consistently produces the highest or near-highest word counts, reflecting its faithful/verbatim processing style. However, Grok introduces factual name substitution errors in several episodes: "Piper Merriam" instead of Gustav Simonsson (ep007), "Michael Perklin" instead of Michael Parenti (ep008), "Mike Hearn" instead of Mike Gogulski (ep008), and "Joseph Lubin" instead of Joseph Chow (ep012-Martin). These errors, while not affecting tier classification, are significant factual inaccuracies.
 
-- **ChatGPT** shows the widest variance: excellent on some episodes (T1 on 6 episodes) but truncated or even refusing on others (T4 on ep010 — refused to process, citing missing timestamps). Unpredictable.
-- **Kimi** is solid and consistent (T1+2 in 85% of episodes) but rarely the best. Good on shorter episodes.
+**Opus** achieves Tier 1 in 14 of 15 episodes on the AssemblyAI base. Its single Tier 2 (episode 013-Zsolt) is due to truncation at ~50 minutes of a 60-minute interview, missing the final 9 minutes. Opus consistently produces the cleanest formatting with proper speaker separation, the most accurate proper noun corrections (including Hungarian diacritics), and the best balance of editorial polish and content fidelity. Opus is the recommended "best output" in 13 of 15 episodes.
 
-### The Truncation Models: DeepSeek, Llama, Qwen, MiniMax, Mistral
-
-These five processors consistently fail on longer episodes (>30 min) due to output token limits:
-- **Mistral**: T3 in 8/15 episodes. Consistently shortest output. Also corrupts timestamps and collapses diarization.
-- **Qwen**: T3 in 8/15 episodes. Minimal intervention — often a near-pass-through leaving errors uncorrected.
-- **DeepSeek**: Name substitution errors (ep012-Martin: "Joseph Chow" → "Joseph Lubin"; ep013-Zsolt: "Zolt Zelfeldi"). T4 failure on ep011 (80 words).
-- **Llama**: Hallucination/corruption loops (ep002: infinite "was like the DAO was the DAO" repetition; ep008: gibberish after line 43). 3 T4 ratings.
-- **MiniMax**: Wildly inconsistent — T4 on some episodes (1,251 words in ep006), T1 on short episodes.
-
-### The Short Episode Effect
-
-On episodes under 30 minutes (ep008, ep012-Martin, ep013-Alex), nearly all processors achieve Tier 1. This confirms the primary failure mode is **output token limits**, not quality. If every episode were 25 minutes, there would be little difference between processors.
-
-### GLM: Systematic Failure
-
-GLM is **Tier 4 (unusable) in 10 of 15 episodes** due to a consistent chain-of-thought leakage bug. Instead of outputting a clean transcript, it dumps thousands of words of internal reasoning, planning notes, and correction analysis. Outputs of 20,000–46,000 words (2–4x expected) are the telltale sign. This is not a truncation issue — it's a fundamental instruction-following failure. **GLM should be removed from the pipeline entirely.**
+**Gemini** achieves Tier 1 in 11 of 14 assessed episodes. Its three Tier 2 results stem from aggressive condensation: episode 001 (85% of max), episode 012-Fabian (59% of max -- the most severe), and episode 013-Zsolt (81% of max). Gemini's condensation tendency worsens with episode length, making it unsuitable as a primary processor for oral history transcripts where verbatim preservation matters. However, Gemini excels at proper noun identification, adding full surnames from contextual knowledge (e.g., "Jeffrey Wilcke," "Lefteris Karapetsas," "Gustav Simonsson") and using code formatting for technical terms.
 
 ---
 
 ## 3. Processor Leaderboard (WhisperX-cloud base)
 
-Data available for 13 episodes (ep011 and ep013-Zsolt had no WhisperX-cloud). Tier assignments estimated from word counts and quality descriptions where explicit tiers weren't provided.
+Data compiled from 14 episodes where WhisperX-cloud-based processor outputs exist (ep011 had no WhisperX-cloud).
 
-| Rank | Processor | T1 | T2 | T3 | T4 | T1+2 Rate | Notes |
-|------|-----------|----|----|----|----|-----------|-------|
-| 1 | **Opus** | **13** | 0 | 0 | 0 | **100%** | Perfect record |
-| 2 | **Gemini** | 9 | 2 | 1 | 0 | 85% | Occasionally condensed |
-| 3 | **Grok** | 9 | 2 | 0 | 1 | 85% | One T4 on ep002 |
-| 4 | **ChatGPT** | 4 | 5 | 2 | 1 | 69% | Refused on ep010 |
-| 5 | **Kimi** | 4 | 5 | 1 | 1 | 69% | Variable |
-| 6 | DeepSeek | 2 | 4 | 3 | 2 | 46% | Catastrophic on some episodes |
-| 7 | Llama | 2 | 4 | 4 | 1 | 46% | Truncation-prone |
-| 8 | MiniMax | 2 | 4 | 4 | 1 | 46% | Better than AssemblyAI base |
-| 9 | Qwen | 2 | 3 | 5 | 1 | 38% | Consistently short |
-| 10 | Mistral | 2 | 3 | 5 | 1 | 38% | Consistently short |
-| 11 | **GLM** | 1 | 2 | 1 | **7** | 23% | Same CoT failure |
+| Processor | Tier 1 | Tier 2 | Tier 3 | Tier 4 | T1 Rate | Consistency |
+|---|---|---|---|---|---|---|
+| **Opus** | **14** | 0 | 0 | 0 | **100%** | Excellent |
+| **Gemini** | 9 | 4 | 0 | 0 | **69%** | Good |
+| **Grok** | 8 | 5 | 0 | 0 | **62%** | Fair |
 
-**Opus maintains a perfect T1 record across both transcriber bases** — the only processor to do so.
+### Per-Episode Breakdown (WhisperX-cloud base)
+
+| Episode | Opus Words | Opus Tier | Gemini Words | Gemini Tier | Grok Words | Grok Tier |
+|---|---|---|---|---|---|---|
+| 001 | 18,470 | T1 | 18,306 | T1 | 18,209 | T1 |
+| 002 | 11,313 | T1 | 11,330 | T1 | 11,419 | T1 |
+| 003 (Bob) | 11,583 | T1 | 12,106 | T1 | 11,988 | T1 |
+| 004 (Taylor) | 9,909 | T1 | 10,283 | T1 | 10,196 | T2 |
+| 005 (Anthony) | 13,349 | T1 | 13,898 | T1 | 14,157 | T1 |
+| 006 (Christoph) | 14,772 | T1 | 14,927 | T1 | 14,782 | T1 |
+| 007 (Jacob) | 2,729 | T1 | 2,704 | T1 | 2,732 | T2 |
+| 008 (Michael) | 4,276 | T1 | 4,084 | T2 | 3,932 | T2 |
+| 009 (Amir) | 8,549 | T1 | 8,280 | T1 | 8,374 | T1 |
+| 010 (Viktor) | 11,284 | T1 | 11,135 | T1 | 11,420 | T2 |
+| 012 (Fabian) | 18,116 | T1 | 5,837 | T2 | 18,232 | T1 |
+| 012 (Martin) | 3,862 | T1 | 3,783 | T1 | 3,609 | T2 |
+| 013 (Alex) | 4,551 | T1 | 4,521 | T1 | 4,450 | T1 |
+| 013 (Zsolt) | 7,919 | T1 | 7,320 | T2 | 8,600 | T1 |
+
+### Analysis
+
+**Opus** achieves a perfect Tier 1 record across all 14 WhisperX-cloud episodes. Its standout capability is **speaker re-separation**: when given coarsely diarized input with merged multi-speaker blocks, Opus consistently reconstructs fine-grained speaker turns. In episode 006, Opus expanded 79 input turn boundaries to 340 output lines (4.3x increase). In episode 008, it expanded 52-line input to 280 lines. This capability makes Opus uniquely resilient to poor transcriber quality.
+
+**Gemini** drops to Tier 2 in 4 episodes on the WhisperX-cloud base. In episode 012-Fabian, it condensed an 18,000-word conversation to just 5,837 words (31% of max) -- its most aggressive condensation. Gemini also fails to decompose merged speaker blocks, inheriting wall-of-text formatting from the source.
+
+**Grok** drops to Tier 2 in 5 episodes on the WhisperX-cloud base. The primary cause is its failure to decompose merged speaker blocks: it typically preserves the coarse paragraph structure of the source, producing outputs with very few lines (e.g., 52 lines for a 25-minute conversation, 92 lines for a 70-minute conversation, 122 lines for a 69-minute conversation). Content is present but readability is severely compromised.
 
 ---
 
 ## 4. Cross-Transcriber Comparison
 
-AssemblyAI is unanimously rated the best transcriber in all 15 episodes. The consistent pattern:
+Comparing the same processor across different transcriber bases reveals how each processor handles varying input quality.
 
-| Attribute | AssemblyAI | WhisperX Local | WhisperX-Cloud |
-|-----------|-----------|---------------|---------------|
-| Speaker turns | Most granular (100–400 turns) | Good (100–350 turns) | Coarsest (50–120 turns) |
-| Diarization | Best separation, consistent labels | Good when not corrupted | Worst — frequent merging/swapping |
-| Word count | Highest | Comparable | Comparable |
-| Downstream AI quality | Best input for processors | Good secondary | Worst — broken diarization propagates |
+### Speaker Re-separation Capability
 
-**Key insight:** AI processors cannot fix diarization errors inherited from the transcriber. WhisperX-cloud's habit of merging multiple speakers into single blocks means all downstream outputs inherit incorrect speaker attribution.
+This is the most important processor differentiator when working with WhisperX-cloud input.
 
----
+| Processor | Re-separation Rating | Typical Behavior | Example |
+|---|---|---|---|
+| **Opus** | **Excellent** | Actively decomposes merged blocks into individual speaker turns; output line count often 3-5x the input line count | ep006: 79 input lines -> 340 output lines; ep008: 52 -> 280 |
+| **Gemini** | **Moderate** | Partially decomposes some blocks; output somewhat more granular than input but retains many merged passages | ep006: 79 input lines -> 196 output lines |
+| **Grok** | **Poor** | Typically preserves the input structure verbatim; output line count matches or nearly matches input line count | ep006: 79 input lines -> 158 output lines; ep008: 52 -> 50 |
 
-## 5. Consensus Pipeline Status
+### Quality Retention Across Bases
 
-| Episode | Status | Notes |
-|---------|--------|-------|
-| 001 | Partial | Intermediate exists (19,755w), no final |
-| 002 | Partial | Intermediate exists, no final |
-| 003 | Not run | — |
-| 004 | Partial | Intermediate exists (11,051w), no final |
-| 005 | Partial | Intermediate exists (15,472w), no final |
-| 006 | Partial | Intermediate exists (15,739w), no final |
-| 007 | **BROKEN** | Corrupted WhisperX input poisoned merge — garbled, repetitive output |
-| 008 | Not run | — |
-| 009 | Not run | — |
-| 010 | Not run | — |
-| 011 | **Degraded** | Final exists (12,587w) but has duplicated paragraphs, truncated speaker tags, merge artifacts. Opus single output is cleaner. |
-| 012 (Fabian) | **BROKEN** | Catastrophic: 3.26x expansion (18,882→61,512w), 0.4–1.3% alignment |
-| 012 (Martin) | Not run | — |
-| 013 (Alex) | Not run | — |
-| 013 (Zsolt) | Not run | — |
+| Metric | Opus | Gemini | Grok |
+|---|---|---|---|
+| AssemblyAI base -> Tier 1 rate | 93% (14/15) | 79% (11/14) | 100% (14/14) |
+| WhisperX-cloud base -> Tier 1 rate | **100%** (14/14) | 69% (9/13) | 62% (8/13) |
+| WhisperX local base -> Tier 1 rate | 100% (10/10)* | 100% (10/10)* | 100% (10/10)* |
+| Quality drop on poor input | Minimal | Moderate-to-severe | Severe (formatting) |
+| Primary failure mode | Rare truncation | Over-condensation | Wall-of-text inheritance |
 
-**Overall verdict: 0/15 episodes have a clean working consensus final.** The pipeline is fundamentally broken:
-- Corrupted transcriber inputs poison the merge (ep007)
-- Divergent AI models cannot be aligned at the word level (ep012-Fabian)
-- Even the "best" result (ep011) introduced defects that don't exist in the single-model output
+*Excluding 3 episodes with corrupted WhisperX local, plus ep011 with no WhisperX. WhisperX local achieves universal Tier 1 when the transcriber produces valid output.
 
-**Recommendation:** Abandon the multi-model consensus approach. A single high-quality model (Opus) consistently produces better results than attempting to merge 11 divergent outputs.
+### Word Count Consistency Across Bases
+
+| Processor | Avg Spread (AssemblyAI vs WhisperX-cloud) | Most Consistent Episode | Least Consistent Episode |
+|---|---|---|---|
+| **Opus** | ~3.5% | ep006 (1.3%) | ep013-Zsolt (19% due to truncation) |
+| **Gemini** | ~8.2% | ep002 (0.7%) | ep012-Fabian (52% due to severe condensation) |
+| **Grok** | ~3.0% | ep006 (1.2%) | ep012-Martin (11%) |
 
 ---
 
-## 6. Processor Tier Distribution (AssemblyAI base)
+## 5. Processor Tier Distribution
 
-Visual summary across all 15 episodes:
+Tier counts across all episodes and transcriber bases combined. Only opus, gemini, and grok are included.
 
-| Processor | T1 | T2 | T3 | T4 | Visual |
-|-----------|----|----|----|----|--------|
-| **Opus** | 13 | 1 | 0 | 0 | `█████████████░` |
-| **Grok** | 12 | 2 | 0 | 0 | `████████████░░` |
-| **Gemini** | 11 | 3 | 0 | 0 | `███████████░░░` |
-| **Kimi** | 5 | 6 | 1 | 0 | `█████▒▒▒▒▒▒░` |
-| **ChatGPT** | 6 | 3 | 3 | 1 | `██████▒▒▒░░░▓` |
-| DeepSeek | 3 | 4 | 5 | 1 | `███▒▒▒▒░░░░░▓` |
-| Llama | 3 | 2 | 5 | 3 | `███▒▒░░░░░▓▓▓` |
-| MiniMax | 2 | 3 | 5 | 3 | `██▒▒▒░░░░░▓▓▓` |
-| Qwen | 3 | 2 | 8 | 1 | `███▒▒░░░░░░░░▓` |
-| Mistral | 1 | 4 | 8 | 1 | `█▒▒▒▒░░░░░░░░▓` |
-| **GLM** | 1 | 2 | 3 | **10** | `█▒▒░░░▓▓▓▓▓▓▓▓▓▓` |
+### Full Tier Matrix
 
-Legend: `█` = T1, `▒` = T2, `░` = T3, `▓` = T4
+| Processor + Base | Tier 1 | Tier 2 | Tier 3 | Tier 4 | Total Assessed |
+|---|---|---|---|---|---|
+| **opus + assemblyai** | 14 | 1 | 0 | 0 | 15 |
+| **opus + whisperx** | 10 | 0 | 0 | 3 | 13 |
+| **opus + whisperx-cloud** | 14 | 0 | 0 | 0 | 14 |
+| **gemini + assemblyai** | 11 | 3 | 0 | 0 | 14 |
+| **gemini + whisperx** | 10 | 0 | 0 | 3 | 13 |
+| **gemini + whisperx-cloud** | 9 | 4 | 0 | 0 | 13 |
+| **grok + assemblyai** | 14 | 0 | 0 | 0 | 14 |
+| **grok + whisperx** | 10 | 0 | 0 | 3 | 13 |
+| **grok + whisperx-cloud** | 8 | 5 | 0 | 0 | 13 |
+| **TOTAL** | **100** | **13** | **0** | **9** | **122** |
+
+*Note: All 9 Tier 4 outputs are exclusively from corrupted WhisperX local bases (ep007, ep012-Fabian, ep013-Zsolt). All three processors correctly identified the corrupted input and produced minimal or empty output -- a correct behavior.*
+
+### Processor Tier Summary (excluding Tier 4 corrupted inputs)
+
+| Processor | Tier 1 | Tier 2 | Total Usable | Tier 1 Rate |
+|---|---|---|---|---|
+| **Opus** | **38** | 1 | 39 | **97.4%** |
+| **Grok** | **32** | 5 | 37 | **86.5%** |
+| **Gemini** | **30** | 7 | 37 | **81.1%** |
+
+### Visual Tier Distribution (AssemblyAI base, 14-15 episodes per processor)
+
+| Processor | T1 Rate | Visual |
+|---|---|---|
+| **Grok** | 100% | `██████████████` (14/14 T1) |
+| **Opus** | 93% | `██████████████░` (14/15 T1, 1 T2) |
+| **Gemini** | 79% | `███████████░░░` (11/14 T1, 3 T2) |
+
+### Visual Tier Distribution (WhisperX-cloud base, 13-14 episodes per processor)
+
+| Processor | T1 Rate | Visual |
+|---|---|---|
+| **Opus** | 100% | `██████████████` (14/14 T1) |
+| **Gemini** | 69% | `█████████░░░░` (9/13 T1, 4 T2) |
+| **Grok** | 62% | `████████░░░░░` (8/13 T1, 5 T2) |
+
+Legend: `█` = Tier 1, `░` = Tier 2
 
 ---
 
-## 7. Best Combinations
+## 6. Best Combinations
 
-Ranked by cross-episode evidence (15 episodes):
+Ranked by consistency, quality, and suitability for oral history transcripts.
 
-| Rank | Combination | Win Rate | Evidence |
-|------|-------------|----------|----------|
-| 1 | **AssemblyAI + Opus** | **11/15** | T1 in 13/15 episodes. Best prose quality, name corrections, and editorial polish. Recommended as primary output in 11 episodes. |
-| 2 | **AssemblyAI + Grok** | 0/15 | T1 in 12/15 episodes. Most faithful word retention, excellent formatting. Strong runner-up. |
-| 3 | **AssemblyAI + Gemini** | 0/15 | T1 in 11/15 episodes. Best technical term corrections. Occasional timestamp issues. |
-| 4 | **AssemblyAI + ChatGPT** | 2/15 | Best prose when it works (6 T1). Won ep008 and ep012-Martin. But refused ep010 and truncated 3 others. |
-| 5 | **AssemblyAI + Kimi** | 1/15 | Won ep013-Zsolt. Good on shorter episodes. 85% T1+2 rate. |
+### Rank 1: AssemblyAI + Opus
+
+**Recommended as primary in: 13/15 episodes**
+
+| Metric | Value |
+|---|---|
+| Tier 1 rate (AssemblyAI base) | 93% (14/15) |
+| Avg completeness | 96.8% |
+| Formatting quality | Excellent -- proper paragraph structure, timestamps, speaker headers on own lines |
+| Name correction quality | Excellent -- most thorough and accurate, includes diacritics (e.g., "Zsolt Felfoldi") |
+| Speaker re-separation | Excellent -- can reconstruct turns from poor input |
+| Unique strength | Best balance of editorial polish and content fidelity |
+| Known weakness | Rare truncation (ep013-Zsolt lost final 9 min); occasionally retains uncorrected names (e.g., "Bob Samuel") |
+
+### Rank 2: AssemblyAI + Grok
+
+**Recommended as primary in: 2/15 episodes (ep013-Zsolt for completeness, ep011 by pipeline score)**
+
+| Metric | Value |
+|---|---|
+| Tier 1 rate (AssemblyAI base) | 100% (14/14) |
+| Avg completeness | 97.1% |
+| Formatting quality | Good -- clean but denser paragraphs, fewer line breaks |
+| Name correction quality | Good but with factual substitution errors in ~4 episodes |
+| Unique strength | Highest word counts; most faithful/verbatim rendering; never truncates |
+| Known weakness | Introduces wrong-person name substitutions; inconsistent capitalization |
+
+### Rank 3: AssemblyAI + Gemini
+
+**Recommended as secondary/reference in all episodes**
+
+| Metric | Value |
+|---|---|
+| Tier 1 rate (AssemblyAI base) | 79% (11/14) |
+| Avg completeness | 95.4% (but drops to 59% on long episodes) |
+| Formatting quality | Good -- clean, sometimes uses code formatting and contextual annotations |
+| Name correction quality | Best -- adds full surnames, identifies obscure proper nouns (Gustav Simonsson, AlethZero, Codius) |
+| Unique strength | Superior proper noun identification; scholarly formatting; best for name verification |
+| Known weakness | Over-condenses long episodes (40-70% content removal on ep012-Fabian); sometimes strips timestamps |
+
+### Rank 4: WhisperX-cloud + Opus
+
+**Recommended as fallback when AssemblyAI is unavailable**
+
+| Metric | Value |
+|---|---|
+| Tier 1 rate | 100% (14/14) |
+| Unique strength | Opus successfully re-separates merged speaker blocks |
+| Known weakness | Some residual diarization confusion from poor source |
+
+### Rank 5: WhisperX (local) + Opus
+
+**Recommended as secondary cross-reference when WhisperX local is not corrupted**
+
+| Metric | Value |
+|---|---|
+| Tier 1 rate | 100% (10/10 non-corrupted episodes) |
+| Unique strength | Sometimes detects more speakers than AssemblyAI (ep004: 5 vs 4); occasionally better on specific proper nouns (ep013-Alex: corrected "Lefteris" and "Rotki" where AssemblyAI+Opus missed them) |
+| Known weakness | 21% corruption rate makes it unreliable |
 
 ---
 
-## 8. Processors to Avoid
+## 7. Processors to Avoid
 
-| Processor | Severity | Reason | Evidence |
-|-----------|----------|--------|----------|
-| **GLM** | **Critical** | Chain-of-thought leakage | T4 in 10/15 episodes. Dumps 20K–46K words of internal reasoning instead of transcript. Must be removed from pipeline. |
-| **Mistral** | High | Consistently truncated | T3 in 8/15 episodes. Also corrupts timestamps and collapses diarization. |
-| **Qwen** | High | Consistently truncated | T3 in 8/15 episodes. Minimal intervention — near-pass-through. |
-| **Llama** | High | Truncation + hallucination | T3/T4 in 8/15 episodes. Corruption loops in ep002 and ep008. |
-| **MiniMax** | High | Wildly inconsistent | T3/T4 in 8/15 episodes. Cannot be trusted — swings from T1 to T4. |
-| **DeepSeek** | Moderate | Truncation + factual errors | T3/T4 in 6/15 episodes. Substitutes wrong person names (ep012-Martin, ep013-Zsolt). |
+### WhisperX-cloud + Grok -- Avoid as primary
+
+**Reason:** Grok does not decompose merged speaker blocks from WhisperX-cloud. Outputs inherit wall-of-text formatting with very few line breaks (sometimes <100 lines for a 60+ minute conversation). Content is technically present but readability is severely compromised. Tier 2 in 5 of 13 episodes.
+
+**Affected episodes:** ep004 (92 lines), ep007 (36 lines), ep008 (50 lines), ep010 (122 lines), ep012-Martin (52 lines)
+
+### WhisperX-cloud + Gemini -- Use with caution
+
+**Reason:** Gemini's condensation tendency is amplified on the WhisperX-cloud base. In episode 012-Fabian, it produced only 5,837 words from an 18,000-word conversation (31% retention). It also fails to fully decompose merged speaker blocks, though to a lesser degree than Grok. Tier 2 in 4 of 13 episodes.
+
+**Affected episodes:** ep008, ep012-Fabian, ep013-Zsolt, and partially ep010
+
+### Grok on any base -- Verify proper names
+
+**Reason:** Grok introduces factual name substitution errors where it replaces an unclear name with a plausible but incorrect person from the same domain. These errors are particularly dangerous because they appear authoritative:
+
+| Episode | Grok Substitution | Correct Name |
+|---|---|---|
+| 007 (Jacob) | "Piper Merriam" | Gustav Simonsson |
+| 008 (Michael) | "Michael Perklin" | Michael Parenti |
+| 008 (Michael) | "Mike Hearn" | Mike Gogulski |
+| 008 (Michael) | "Michael Goldstein" | Mike Gogulski |
+| 012 (Martin) | "Joseph Lubin" | Joseph Chow |
+| 012 (Fabian) | "Yann LeCun" | Yann Levreau |
+
+### Gemini on long episodes (>60 min) -- Verify completeness
+
+**Reason:** Gemini's condensation scales with episode length. On shorter episodes, condensation is minimal. On longer episodes, condensation becomes severe.
+
+| Episode Duration Range | Gemini Avg Completeness | Examples |
+|---|---|---|
+| <30 min | ~97% | ep007 (94%), ep008 (100%), ep012-Martin (100%), ep013-Alex (100%) |
+| 30-60 min | ~93% | ep009 (97%), ep010 (100%), ep013-Zsolt (81%) |
+| 60-90 min | ~90% | ep003 (100%), ep004 (100%), ep005 (98%), ep011 (not assessed) |
+| >90 min | ~72% | ep001 (85%), ep012-Fabian (59%) |
 
 ---
 
-## 9. Recommendations
+## 8. Recommendations
 
-### Default pipeline configuration
-- **Transcriber:** AssemblyAI only (100% reliability, unanimously best)
-- **Primary processor:** Opus (13/15 Tier 1, 11/15 best output wins)
-- **Secondary processors:** Grok and Gemini (for cross-reference and validation)
-- **Drop from pipeline:** GLM (broken), Mistral, Qwen, Llama, MiniMax (all add cost without value)
+### Primary Pipeline
 
-### Optimal processor set (cost vs quality)
-Run only **3 processors** instead of 11:
-- **Opus** (primary output)
-- **Grok** (highest fidelity cross-reference)
-- **Gemini** (best technical corrections)
+1. **Use AssemblyAI as the primary transcriber for all episodes.** It has a 100% reliability rate, the best diarization, and the highest word counts. There is no scenario where another transcriber outperforms AssemblyAI across all metrics.
 
-This eliminates 8 models that either fail catastrophically (GLM) or consistently truncate (the rest), reducing API costs by ~70%.
+2. **Use Opus as the primary AI processor.** It achieves Tier 1 in 97.4% of usable outputs, has the best formatting quality, the most accurate name corrections, and uniquely can reconstruct speaker turns from poorly diarized input. Its only weakness (rare truncation on one episode) is easily caught by comparing word counts.
 
-### Consensus pipeline
-**Do not use in current form.** 0/15 episodes produced clean output. Instead:
-- Use Opus single-model output as the canonical transcript
-- Cross-reference with Grok and Gemini for name/term corrections
-- Manual review for proper nouns and technical terminology
+3. **Use Grok as the secondary/completeness-check processor.** It produces the highest word counts and never truncates on the AssemblyAI base, making it a useful completeness check against Opus. Always verify proper names against the Opus output, as Grok introduces factual name substitution errors.
 
-### WhisperX local
-Keep as optional secondary transcriber but add **corruption detection** before processing:
-- Detect repeated character patterns (`!!!!!!`, "Thank you" loops)
-- Skip downstream processing if corruption detected
-- Do not feed corrupted output into consensus pipeline
+4. **Use Gemini as a reference for proper noun verification.** Gemini's ability to add full surnames and contextual annotations makes it invaluable for name verification, even if its condensation makes it unsuitable as a primary transcript source for long episodes.
 
-### Validation gates to add
-1. **Output word count check**: Flag if output exceeds 150% of input (GLM chain-of-thought)
-2. **Output word count check**: Flag if output is below 25% of expected (severe truncation)
-3. **Corruption detection**: Check for repeated token patterns in transcriber output
-4. **Name verification**: Cross-check guest/host names against episode metadata
+### Transcriber Strategy
+
+5. **Retain AssemblyAI as the sole production transcriber.** Its 100% reliability and best-in-class diarization make it the only transcriber needed for production workflows.
+
+6. **Discontinue WhisperX (local) for production use** unless the corruption issue (hallucinated "Thank you" loops, exclamation mark strings) is resolved. A 21% failure rate is unacceptable. If local WhisperX must be used, implement a corruption check before processing.
+
+7. **Retain WhisperX-cloud as an optional tertiary source** for cross-reference only. Its poor diarization means it should never be the primary source, but its content capture is complete and Opus can recover reasonable structure from it.
+
+### Quality Assurance
+
+8. **Implement word count comparison** between Opus and Grok outputs. If Grok's word count exceeds Opus by more than 15%, check for Opus truncation. If Opus's word count exceeds Gemini by more than 25%, check for Gemini over-condensation.
+
+9. **Implement a proper noun verification step** using Gemini's output as a reference for full names and correct spellings, while using Opus's output as the base transcript.
+
+10. **Flag Grok name substitutions** by comparing Grok's proper nouns against Opus and Gemini. Any name present in Grok but absent from both other processors should be manually verified against the audio.
+
+11. **For episodes over 60 minutes**, always check that Opus reached the final timestamp. If truncated, supplement the missing section from the Grok output.
 
 ---
 
 ## Appendix: Per-Episode Summaries
 
-### Episode 001
-~112 min, 3 speakers. AssemblyAI best transcriber. Top: Opus (18,802w), Grok (17,855w), Gemini (16,009w). GLM T4 (chain-of-thought). Llama T4 (1,078w). Consensus partial — intermediate only. Best: `assemblyai_opus.md`.
-→ [Full report](episode001/episode001_quality_assessment.md)
+### Episode 001 (Kieren James-Lubin, Jim Hermosdia, Victor Wong)
+~116 min | 9 outputs assessed | All Tier 1 except assemblyai_gemini (Tier 2, 85% condensation). **Best: assemblyai_opus** (18,802 words). AssemblyAI provided the best 3-speaker diarization. Opus delivered the most complete and best-formatted output. Gemini over-condensed the AssemblyAI base but performed well on WhisperX bases. All transcribers corruption-free.
+[Full report](episode001/episode001_quality_assessment.md)
 
-### Episode 002
-~90 min, 3 speakers (BlockApps co-founders). All transcribers working. Top: Opus (11,800w), ChatGPT (10,200w). Llama T4 (catastrophic repetition loop). Consensus partial. Best: `assemblyai_opus.md`.
-→ [Full report](episode002/episode002_quality_assessment.md)
+### Episode 002 (BlockApps Co-founders)
+~60 min | 9 outputs assessed | **All 9 outputs Tier 1** -- the cleanest episode across the entire series. **Best: assemblyai_opus** (11,814 words). Word counts tightly clustered (7% range). Both WhisperX variants had hallucinated speaker name artifacts ("Justin Delacruz, Ph.D.") but content was complete. Formatting quality was the main differentiator.
+[Full report](episode002/episode002_quality_assessment.md)
 
-### Episode 003 — Bob Summerwill
-~60 min, 4 speakers. All transcribers working. Top: Opus, Gemini, Grok, ChatGPT, Kimi (all T1, ~11K words). GLM T4 on all 3 bases. Best: `assemblyai_opus.md`.
-→ [Full report](episode003-bob-summerwill/episode003-bob-summerwill_quality_assessment.md)
+### Episode 003 (Bob Summerwill)
+~79 min | 9 outputs assessed | **All 9 outputs Tier 1.** **Best: assemblyai_opus** (11,554 words). Bob speaks clearly at a measured pace, resulting in excellent ASR quality across all transcribers. WhisperX-cloud had the worst diarization (Bob's speech frequently misattributed). All processors handled name corrections well.
+[Full report](episode003-bob-summerwill/episode003-bob-summerwill_quality_assessment.md)
 
-### Episode 004 — Taylor Gerring
-~60 min. WhisperX local had best diarization for once. Top: Opus, Gemini (both T1, ~10.2K words). GLM T4 (chain-of-thought on all 3 bases). MiniMax T4. Best: `assemblyai_opus.md`.
-→ [Full report](episode004-taylor-gerring/episode004-taylor-gerring_quality_assessment.md)
+### Episode 004 (Taylor Gerring)
+~71 min | 9 outputs assessed | 8 Tier 1, 1 Tier 2 (whisperx-cloud_grok -- wall-of-text, 92 lines). **Best: assemblyai_opus** (10,256 words). WhisperX local uniquely detected 5 speakers (vs 4 for AssemblyAI). Grok failed to decompose WhisperX-cloud's merged blocks. All transcribers struggled with "Meierskappel."
+[Full report](episode004-taylor-gerring/episode004-taylor-gerring_quality_assessment.md)
 
-### Episode 005 — Anthony Di Onofrio
-~80 min, 4 speakers. Top: Opus (14,308w), Grok (14,978w), Gemini (14,639w). GLM T4 (19K–46K words of chain-of-thought). Gemini resets timestamps to 00:00. Best: `assemblyai_opus.md`.
-→ [Full report](episode005-anthony-d-onofrio/episode005-anthony-d-onofrio_quality_assessment.md)
+### Episode 005 (Anthony D'Onofrio)
+~73 min | 9 outputs assessed | **All 9 outputs Tier 1.** **Best: assemblyai_opus** (14,308 words). WhisperX-cloud had severely collapsed diarization (700+ word multi-speaker blocks). Gemini stripped timestamps from the WhisperX output. Grok preserved more raw errors ("metallic" for Vitalik). Content-rich episode with many proper nouns.
+[Full report](episode005-anthony-d-onofrio/episode005-anthony-d-onofrio_quality_assessment.md)
 
-### Episode 006 — Christoph Jentzsch
-~80 min, 4 speakers. Top: Opus (14,828w), Gemini (15,145w), Grok (14,955w). GLM T4 (32K–46K words). MiniMax T4 (1,251w). 6 models truncated to 25–45%. Best: `assemblyai_opus.md`.
-→ [Full report](episode006-christoph-jentzsch/episode006-christoph-jentzsch_quality_assessment.md)
+### Episode 006 (Christoph Jentzsch)
+~87 min | 9 outputs assessed | **All 9 outputs Tier 1.** **Best: assemblyai_opus** (14,828 words). Showcase episode for Opus's speaker re-separation capability (79 WhisperX-cloud input lines -> 340 output lines, a 4.3x increase). Grok had the tightest word count spread (1.2%) across bases. All processors handled the technically dense DAO/Slock.it content well.
+[Full report](episode006-christoph-jentzsch/episode006-christoph-jentzsch_quality_assessment.md)
 
-### Episode 007 — Jacob Czepluch
-~50 min. WhisperX local BROKEN ("Thank you" hallucination). Top: Opus, ChatGPT, Gemini, Grok (all T1). GLM T2 (worked on this episode). Consensus BROKEN — corrupted transcriber poisoned merge. Best: `assemblyai_opus.md`.
-→ [Full report](episode007-jacob-czepluch/episode007-jacob-czepluch_quality_assessment.md)
+### Episode 007 (Jacob Czepluch)
+~16 min | 6 usable outputs (3 Tier 4 from corrupted WhisperX local). **Best: assemblyai_gemini** (2,747 words) -- the only episode where Gemini is recommended over Opus, due to superior proper noun accuracy (Gustav Simonsson, AlethZero, ETHPrague). Grok introduced "Piper Merriam" factual error. WhisperX local completely corrupted ("Thank you" hallucinations).
+[Full report](episode007-jacob-czepluch/episode007-jacob-czepluch_quality_assessment.md)
 
-### Episode 008 — Michael Parenti
-~26 min (short). Nearly all processors T1. WhisperX local produced best input for processors here. Llama T4 (gibberish). GLM T3 (chain-of-thought). Best: `assemblyai_chatgpt.md`.
-→ [Full report](episode008-michael-parenti/episode008-michael-parenti_quality_assessment.md)
+### Episode 008 (Michael Parenti)
+~26 min | 9 outputs assessed | 6 Tier 1, 2 Tier 2 (whisperx-cloud gemini/grok poor formatting). **Best: assemblyai_opus** (4,273 words). Opus was the only processor to achieve Tier 1 across all three bases due to its speaker re-diarization capability. Gemini misidentified the guest as "Michael Polzl"; Grok as "Michael Perklin." Multiple name errors across processors.
+[Full report](episode008-michael-parenti/episode008-michael-parenti_quality_assessment.md)
 
-### Episode 009 — Amir Taaki
-~57 min. Top: Opus (9,196w), Kimi (9,105w), Gemini (8,884w), Grok (8,655w). GLM T4 on 2/3 bases. 5 models truncated to 36–56%. Best: `assemblyai_opus.md`.
-→ [Full report](episode009-amir-taaki/episode009-amir-taaki_quality_assessment.md)
+### Episode 009 (Amir Taaki)
+~57 min | 9 outputs assessed | **All 9 outputs Tier 1** (though WhisperX-cloud gemini/grok had wall-of-text formatting with only 72 lines each). **Best: assemblyai_opus** (9,196 words, 800 lines). Opus excelled at recovering structure from WhisperX-cloud (332 lines vs 72 for Gemini/Grok). Critical test word "ahistorical" correctly rendered by Grok.
+[Full report](episode009-amir-taaki/episode009-amir-taaki_quality_assessment.md)
 
-### Episode 010 — Viktor Tron
-~60 min. Top: Opus (10,896w), Gemini (11,497w), Grok (10,909w). **ChatGPT refused** (241w, cited missing timestamps). GLM T3 (chain-of-thought). Best: `assemblyai_opus.md`.
-→ [Full report](episode010-viktor-tron/episode010-viktor-tron_quality_assessment.md)
+### Episode 010 (Viktor Tron)
+~69 min | 9 outputs assessed | 8 Tier 1, 1 Tier 2 (whisperx-cloud_grok -- 122 lines, wall-of-text). **Best: assemblyai_opus** (10,896 words). Gemini and Grok dropped timestamps on multiple outputs. Gemini's whisperx output had the best name annotations with bracketed clarifications. Opus was the only processor with timestamps on the AssemblyAI base.
+[Full report](episode010-viktor-tron/episode010-viktor-tron_quality_assessment.md)
 
-### Episode 011 — Ryan Taylor
-~71 min. AssemblyAI only (no WhisperX). Top: Opus (12,102w). DeepSeek T4 (80 words — near-total failure). Consensus complete but degraded (duplicated paragraphs, truncated tags). Opus single output is cleaner than consensus. Best: `assemblyai_opus.md`.
-→ [Full report](episode011-ryan-taylor/episode011-ryan-taylor_quality_assessment.md)
+### Episode 011 (Ryan Taylor)
+~71 min | **Only 1 output assessed** (assemblyai_opus, 12,102 words, Tier 1). No WhisperX transcriptions exist. No Gemini or Grok output files were generated despite pipeline quality scores existing. The single Opus output is publication-ready with excellent formatting and proper noun handling.
+[Full report](episode011-ryan-taylor/episode011-ryan-taylor_quality_assessment.md)
 
-### Episode 012 — Fabian Vogelsteller
-Long episode (~19K words). WhisperX local BROKEN (`!!!!!!`). Top: Opus (18,837w), Grok (18,474w), GLM5 (17,665w). 5 models severely truncated. Consensus BROKEN (3.26x expansion). Best: `assemblyai_opus.md`.
-→ [Full report](episode012-fabian-vogelsteller/episode012-fabian-vogelsteller_quality_assessment.md)
+### Episode 012 (Fabian Vogelsteller)
+~116 min | 6 usable outputs (3 Tier 4 from corrupted WhisperX local). **Best: assemblyai_opus** (18,837 words). Gemini's most severe condensation: assemblyai_gemini reduced to 11,175 words (59%); whisperx-cloud_gemini to 5,837 words (31%). Grok introduced "Yann LeCun" error. WhisperX local corrupted (exclamation marks). All Opus and Grok outputs are Tier 1.
+[Full report](episode012-fabian-vogelsteller/episode012-fabian-vogelsteller_quality_assessment.md)
 
-### Episode 012 — Martin Becze
-~25 min (short). Nearly all processors T1. GLM T4 (27,771w chain-of-thought). DeepSeek wrong name substitution ("Joseph Chow" → "Joseph Lubin"). Best: `assemblyai_chatgpt.md`.
-→ [Full report](episode012-martin-becze/episode012-martin-becze_quality_assessment.md)
+### Episode 012 (Martin Becze)
+~26 min | 9 outputs assessed | 8 Tier 1, 1 Tier 2 (whisperx-cloud_grok -- 52 lines, merged paragraphs). **Best: assemblyai_opus** (3,850 words). Grok (WhisperX base) systematically replaced "Joseph Chow" with "Joseph Lubin" -- a significant factual error. Opus had the tightest word count spread across bases (3%, 129 words). Gemini correctly identified "Codius."
+[Full report](episode012-martin-becze/episode012-martin-becze_quality_assessment.md)
 
-### Episode 013 — Alex Van de Sande
-~30 min. WhisperX-cloud broken diarization (speakers swapped). 28/33 outputs T1. GLM T4 on all 3 bases. Llama hallucinated "Radicle" for "Rotki". Best: `assemblyai_chatgpt.md`.
-→ [Full report](episode013-alex-van-de-sande/episode013-alex-van-de-sande_quality_assessment.md)
+### Episode 013 (Alex Van de Sande)
+~30 min | 9 outputs assessed | **All 9 outputs Tier 1.** **Best: whisperx_gemini or whisperx_opus** -- the only episode where WhisperX-based outputs outperformed AssemblyAI-based ones, because WhisperX processors correctly identified "Lefteris," "Rotki," and "Infura" where AssemblyAI+Opus missed these corrections. Short episode (30 min) helped all processors achieve full coverage.
+[Full report](episode013-alex-van-de-sande/episode013-alex-van-de-sande_quality_assessment.md)
 
-### Episode 013 — Zsolt Felfoldi
-~40 min. WhisperX local BROKEN (`!!!!!!`). Top: Kimi (8,185w), GLM (8,178w), Grok (7,859w). GLM worked on this episode. DeepSeek misspelled guest name. Consensus not run. Best: `assemblyai_kimi.md`.
-→ [Full report](episode013-zsolt-felfoldi/episode013-zsolt-felfoldi_quality_assessment.md)
+### Episode 013 (Zsolt Felfoldi)
+~60 min | 6 usable outputs (3 Tier 4 from corrupted WhisperX local). 4 Tier 1, 2 Tier 2. Unusual episode: **whisperx-cloud_grok** had the highest word count (8,600) and **assemblyai_grok** (7,859 words) is the recommended AssemblyAI-base output. Opus (assemblyai) truncated at 50 minutes, missing the final 9 minutes on multi-client philosophy, EF growth, and Raiden. Best balance: whisperx-cloud_opus (7,919 words).
+[Full report](episode013-zsolt-felfoldi/episode013-zsolt-felfoldi_quality_assessment.md)


### PR DESCRIPTION
## Summary
- Re-ran all 15 per-episode self-assessments after removing 9 underperforming processors
- Regenerated the overall quality report reflecting only opus, grok, and gemini
- Removed all consensus pipeline references from assessment reports

## Key findings (updated)
- **Opus**: 97.4% Tier 1 rate on usable outputs, best at speaker re-separation
- **Grok**: 100% Tier 1 on AssemblyAI base, but name substitution errors in 4 episodes
- **Gemini**: Over-condenses long episodes (>90 min), 79% Tier 1 on AssemblyAI base
- **Best combo**: AssemblyAI + Opus across all 15 episodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)