### PR TITLE
Add Qwen3.5 Plus as fourth hosted processor

### DIFF
--- a/.claude/commands/full-pipeline.md
+++ b/.claude/commands/full-pipeline.md
@@ -58,7 +58,7 @@ When the user invokes this command:
 /full-pipeline episode001.mp3 --force
 
 # All processors
-/full-pipeline episode001.mp3 --processors opus,grok,gemini
+/full-pipeline episode001.mp3 --processors opus,grok,gemini,qwen
 ```
 
 ## Pipeline Steps

--- a/.claude/commands/post-process.md
+++ b/.claude/commands/post-process.md
@@ -22,6 +22,7 @@ Run AI post-processing on transcripts to fix technical terms, names, and formatt
 | opus | Claude Opus 4.6 | 1M | Premium quality |
 | gemini | Gemini 3.1 Pro | 1M | Long documents |
 | grok | Grok 4 | 256K | High benchmark performance |
+| qwen | Qwen3.5 Plus | 1M | Multilingual, open weights |
 
 ### Local (ollama, requires 2x RTX 3090)
 | Processor | Model | VRAM |
@@ -59,7 +60,7 @@ When the user invokes this command:
 /post-process intermediates/episode001/episode001_whisperx.md --processors opus
 
 # All hosted processors
-/post-process intermediates/episode001/episode001_whisperx.md --processors opus,gemini,grok
+/post-process intermediates/episode001/episode001_whisperx.md --processors opus,gemini,grok,qwen
 
 # Local mode (requires 2x RTX 3090)
 /post-process intermediates/episode001/episode001_whisperx.md --processors glm --mode local

--- a/.claude/commands/video-caption.md
+++ b/.claude/commands/video-caption.md
@@ -14,7 +14,7 @@ Generate captioned videos with burned-in subtitles from transcripts.
 - `--transcriber <name>` - Transcription service (default: whisperx)
   - Options: whisperx, whisperx-cloud, assemblyai
 - `--processor <name>` - AI post-processor for transcript cleanup (optional)
-  - Options: opus, gemini, grok
+  - Options: opus, gemini, grok, qwen
 - `--title <text>` - Title overlay at top of screen
 - `--force-cpu` - Force CPU mode for WhisperX
 

--- a/AI_PROVIDERS.md
+++ b/AI_PROVIDERS.md
@@ -1,6 +1,6 @@
 # AI Providers for Transcript Post-Processing
 
-All 3 hosted models are accessed through **OpenRouter** with a single API key.
+All 4 hosted models are accessed through **OpenRouter** with a single API key.
 Get your key from: https://openrouter.ai/keys
 
 **Local Mode**: 5 models run locally via ollama on dual RTX 3090s (48GB).
@@ -12,6 +12,7 @@ Get your key from: https://openrouter.ai/keys
 | **opus** | Claude Opus 4.6 | `anthropic/claude-opus-4.6` | 1M | Closed |
 | **gemini** | Gemini 3.1 Pro | `google/gemini-3.1-pro-preview` | 1M | Closed |
 | **grok** | Grok 4 | `x-ai/grok-4` | 256K | Closed |
+| **qwen** | Qwen3.5 Plus | `qwen/qwen3.5-plus-02-15` | 1M | Open |
 
 ## Local Models (ollama, fit on 48GB)
 
@@ -50,7 +51,7 @@ python3 scripts/test_ai_providers.py
 python3 scripts/process_single_post_process.py transcript.md --processors opus
 
 # All hosted processors
-python3 scripts/process_single_post_process.py transcript.md --processors opus,gemini,grok
+python3 scripts/process_single_post_process.py transcript.md --processors opus,gemini,grok,qwen
 
 # Explicit hosted mode
 python3 scripts/process_single_post_process.py transcript.md --processors grok --mode hosted
@@ -78,7 +79,7 @@ python3 scripts/process_single_post_process.py transcript.md --processors glm,de
 
 ### Test Context Limits
 ```bash
-python3 scripts/test_context_limits.py --providers opus,gemini,grok
+python3 scripts/test_context_limits.py --providers opus,gemini,grok,qwen
 python3 scripts/test_context_limits.py --providers all
 ```
 
@@ -99,6 +100,11 @@ python3 scripts/test_context_limits.py --providers all
 - **Best For**: Very long documents, technical content
 - **Notes**: Dynamic thinking by default
 
+### Qwen3.5 Plus (`qwen`)
+- **Context**: 1M tokens
+- **Best For**: Multilingual content, agentic tasks
+- **Notes**: 397B MoE (17B active), open weights, 201 languages
+
 ## Recommendations
 
 ### For Typical Transcripts (60-90 min)
@@ -106,16 +112,17 @@ python3 scripts/test_context_limits.py --providers all
 - **Token count**: ~20,000-40,000 tokens
 - **Total with prompts**: ~45,000 tokens
 
-All 3 models have sufficient context for typical transcripts.
+All 4 models have sufficient context for typical transcripts.
 
 ### Best Quality
 1. **Claude Opus 4.6** - Consistently Tier 1 in 13/15 episodes
 2. **Grok 4** - Strong benchmark performance
 3. **Gemini 3.1 Pro** - Reliable, good for long content
+4. **Qwen3.5 Plus** - New, under evaluation
 
 ## OpenRouter Benefits
 
-- **Single API key** for all 3 models
+- **Single API key** for all 4 models
 - **Unified billing** across providers
 - **Automatic failover** if a provider is down
 - **Pay-as-you-go** with no monthly minimums

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ All hosted models accessed via **OpenRouter** (single API key). See [AI_PROVIDER
 | **opus** | Claude Opus 4.6 | 1M | Premium quality, complex reasoning |
 | **gemini** | Gemini 3.1 Pro | 1M | Very long documents, technical |
 | **grok** | Grok 4 | 256K | High benchmark performance |
+| **qwen** | Qwen3.5 Plus | 1M | Multilingual, open weights |
 
 ### Post-Processing Commands
 
@@ -70,7 +71,7 @@ All hosted models accessed via **OpenRouter** (single API key). See [AI_PROVIDER
 python3 scripts/process_single_post_process.py transcript.md --processors opus
 
 # All processors
-python3 scripts/process_single_post_process.py transcript.md --processors opus,gemini,grok
+python3 scripts/process_single_post_process.py transcript.md --processors opus,gemini,grok,qwen
 ```
 
 ## Output Structure

--- a/outputs/episode012-martin-becze/episode012-martin-becze_assemblyai_qwen.md
+++ b/outputs/episode012-martin-becze/episode012-martin-becze_assemblyai_qwen.md
@@ -1,0 +1,365 @@
+**[00:02] SPEAKER_00:** Test. Hello, can you hear me?
+
+**[00:05] SPEAKER_01:** Hello? Hello?
+
+**[00:13] SPEAKER_00:** We good? We're both good, yeah. So, hello, I'm Bob Summerwill here with Early Days of Ethereum and talking to Martin Swende. Hello. Or is it Swende?
+
+**[00:29] SPEAKER_01:** We say "Swende," but "Swende," you know, back says that works.
+
+**[00:34] SPEAKER_00:** Okay. So yeah, thanks for talking to us. You are a very OG. You are more OG than I am, by a couple of years maybe. Even so, I mean, what were you doing prior to Ethereum that led you to Ethereum?
+
+**[00:54] SPEAKER_01:** Yeah, that's a good question. So like prior to Ethereum, I had gotten into Bitcoin for a bit, so I was actually at Occupy Wall Street and I set up the Bitcoin donation address for OWS and started doing some development, just regular like, you know, Web2 development. But as my projects developed, I started wondering how to decentralize them, as you naturally do if you've played around with crypto. And you know, I was highly influenced by Bitcoin and BitTorrent and this is around the time Namecoin also.
+
+**[01:45] SPEAKER_00:** Right, right.
+
+**[01:47] SPEAKER_01:** So I was sort of like wanted to extend the concepts of Namecoin for my own project, which at the time was a geospatial map thing that like displayed what was happening around you. And it was like supposed to be federated and I wanted to have like a DNS system that we could resolve like a location to like these servers, so called it GoDNS. And I was like looking at how Namecoin implemented it, I was like, ah, this is going to be a pain. I'm going to have to fork it, you know, rebuild everything, get people to mine it. This is a lot of work. And then as you naturally do, you're like, well, this could just be generalized. Right? Yeah. So, you know, this is around the time that Vitalik, he had written some articles, I believe in Bitcoin Magazine, but maybe not on DAOs and DEXs.
+
+**[02:52] SPEAKER_00:** Yes.
+
+**[02:52] SPEAKER_01:** So I was very interested in that too. And I was following that work. And then yeah, I saw the white paper drop and like, yeah, as soon as I saw the white paper drop I was like, yeah, that I need that. What I need. That makes a lot of sense. So then I started hacking on it because that was before any code, you know, I think was really operable.
+
+**[03:16] SPEAKER_00:** Right.
+
+**[03:17] SPEAKER_01:** And I wanted to get my hands onto it. Like I think Alethzero is up. But it was like really rough. Yeah, it was up on GitHub. And you know, I was a JavaScript programmer, right. So I was like, well, I better implement this in JavaScript, because that's what I know and I really just wanted to get my hands on it and really understand how it worked.
+
+**[03:41] SPEAKER_00:** Right. So, yeah, we were just looking at some commit first commit dates. So we saw that Joseph Chow had had a first commit on Node Ethereum in February and then we found March 2014 is probably the first commit on your side. So, yeah, I mean the white paper had come out in November of the previous year, but I was looking, you know, the C++ and Go clients started in very late December. But so, yeah, you know, a couple of months in, as you say, it's all going to be a bit rough. Yeah. And yeah, I mean it wasn't until April that you had the Yellow Paper. You know, that came a little later, I think. I think maybe April-ish was when Geth and cpp-ethereum were maybe, you know, kind of working.
+
+**[04:42] SPEAKER_01:** Talking to each other.
+
+**[04:43] SPEAKER_00:** Yes. Yeah, yeah, yeah. I'll have to find the date. There is that. I did see like, you know, maybe a tweet of when that was and I think it was Charles sent a transaction to Gav or the other way around.
+
+**[04:58] SPEAKER_01:** Was it Gavcoin maybe that? Well, here's an interesting gap, Coin came later.
+
+**[05:04] SPEAKER_00:** Well, there was a meetup in London in October 2014 where both Gav and Jeff were basically doing hey, here's the status of Ethereum and Roadmap kind of thing. You know, like an hour long, big thorough thing. But what they did at that was Gav had got Gavcoin, which was written in LLL.
+
+**[05:26] SPEAKER_01:** Yeah.
+
+**[05:27] SPEAKER_00:** And Jeff had JeffCoin, which was written in Mutan and they had an on-chain DEX. It was an on-chain order book. Really clunky, you know, like here I'm offering, you know, three Gavcoin for 10 Jeffcoin or what have you. But they demonstrated it there and you know, did a transaction to put like a, you know, an offer into the order book and then Jeff's like doing pressing the button to mine a block and that's really funny exchange happened. But, but so, I mean, were there weren't there many people where you were living that were regularly having meetups and being involved with Ethereum?
+
+**[06:10] SPEAKER_01:** No, not at all. I was living in Indiana, so very rural and it's just yeah, it was completely. I only connected online.
+
+**[06:20] SPEAKER_00:** Right.
+
+**[06:21] SPEAKER_01:** And I was, I remained that way for, you know, some time.
+
+**[06:25] SPEAKER_00:** Right.
+
+**[06:28] SPEAKER_01:** And it wasn't till, I don't know, a few months later, I was trying to get a job at Ripple.
+
+**[06:36] SPEAKER_00:** Oh, yes.
+
+**[06:39] SPEAKER_01:** Ripple also. So they had a, I don't remember what it was called, but they were working on a VM.
+
+**[06:46] SPEAKER_00:** Yeah. Not yeah, I can't remember. Codex or something. It wasn't like that.
+
+**[06:52] SPEAKER_01:** Maybe.
+
+**[06:53] SPEAKER_00:** Yeah, well, I was like.
+
+**[06:56] SPEAKER_01:** So I was interested in that. And I had been working on Ethereum, implementing the Ethereum Virtual Machine in JavaScript, so they thought that was pretty cool and they flew me out for an interview right at their office. And that is when I met Vitalik, because not at Ripple.
+
+**[07:18] SPEAKER_00:** Right.
+
+**[07:18] SPEAKER_01:** He just happened to be in San Francisco at the same time.
+
+**[07:22] SPEAKER_00:** Right.
+
+**[07:22] SPEAKER_01:** And also Joseph Chow for the first time.
+
+**[07:26] SPEAKER_00:** Do you know when that might have been?
+
+**[07:28] SPEAKER_01:** Unfortunately, no. I'm really bad at this. But it was definitely past March, like sometime in the summer. And then that's when I met up with everyone proper. And Vitalik's like, nah, just come work on Ethereum.
+
+**[07:44] SPEAKER_00:** Right.
+
+**[07:45] SPEAKER_01:** So, yeah, that's what I did.
+
+**[07:48] SPEAKER_00:** So was that working for ETHDev as a contractor?
+
+**[07:53] SPEAKER_01:** So, yes, I was working for ETHDev as a contractor at that point.
+
+**[07:58] SPEAKER_00:** Right. And yeah, Vitalik notoriously also nearly worked for Ripple but could not get his work permit. So, yeah, the world might have looked very, very different if Vitalik had joined Ripple as an intern back then, rather than Ethereum.
+
+**[08:17] SPEAKER_01:** Sort of like they failed to get everyone, but if they had, Ripple also may have looked a lot different.
+
+**[08:24] SPEAKER_00:** Yeah. Well, some of my very earliest meetups I went to at the start of 2014, it was like, here's a demo of Ripple because it really was a lot less of a tribal setup. Right. Like, everyone was Bitcoiners, because that's all there was. And then it's like, oh, there are these other things appearing and oh yeah, it's a different form of consensus. Here's a different flavor.
+
+**[08:45] SPEAKER_01:** And I was actually interested in there was an early version of Ripple made by this guy in Canada.
+
+**[08:53] SPEAKER_00:** Yeah, Ryan Fugger.
+
+**[08:54] SPEAKER_01:** Yes.
+
+**[08:55] SPEAKER_00:** Who lives in Vancouver, same as me.
+
+**[08:58] SPEAKER_01:** Oh, nice.
+
+**[08:58] SPEAKER_00:** I've not met him ever, though.
+
+**[09:00] SPEAKER_01:** So I was interested in that version. Like, you were able yeah, I'm not sure if I'm going to be able to actually recall, but you were like able to it was like debt. You were able to open debt lines to various people, you know.
+
+**[09:14] SPEAKER_00:** Yeah.
+
+**[09:15] SPEAKER_01:** And then, you know, debt would flow through the people.
+
+**[09:17] SPEAKER_00:** That's right. It would ripple through.
+
+**[09:19] SPEAKER_01:** Yeah, ripple through. And this was pre-blockchain. It was yeah, it was built in like PHP. They had a demo in like PHP. I had signed up on it, playing around. I was like offering my services on it.
+
+**[09:33] SPEAKER_00:** Right.
+
+**[09:34] SPEAKER_01:** But yeah, then that's how I got interested in Ripple. But yeah, then they ended up doing moving in a slightly different direction.
+
+**[09:42] SPEAKER_00:** Slightly different, yes. I think it was 2004, Ryan's work. Yeah, around then.
+
+**[09:47] SPEAKER_01:** Very early.
+
+**[09:48] SPEAKER_00:** Absolutely. So when you were then working full time on Ethereum, did you have many collaborators? Were many people working on the code together with you?
+
+**[10:02] SPEAKER_01:** It was like me and Joseph Chow to start with. And then Joseph Chow eventually went off and he started working on BTC Relay.
+
+**[10:14] SPEAKER_00:** Yeah, I don't know if that's a very interesting project.
+
+**[10:17] SPEAKER_01:** Yeah. So he did that next. But yeah, there was a bunch of people that came coming in and out. Dan Finlay helped out quite a bit.
+
+**[10:26] SPEAKER_00:** Right.
+
+**[10:28] SPEAKER_01:** I was actually looking through the commits and saw he actually committed quite a few things. And then Alex Beregszaszi became involved and there were several other people that I don't remember anymore, but those I think were the main characters back then.
+
+**[10:47] SPEAKER_00:** Yeah. So, I mean, for Dan Finlay, was that before he was doing MetaMask?
+
+**[10:54] SPEAKER_01:** Yeah. So, you know, we met I met Dan Finlay at like, it was Mailchimp, may have been Mailchimp at a party in SF or Hangout. And he started just asking me a ton of questions about Ethereum and we ended up chatting for a very long time. And then, yeah, he was, you know, he was very proficient in JavaScript as well. So he started hacking a bit on ethereumjs.
+
+**[11:26] SPEAKER_00:** Right. Something I think some people have asked and I didn't know the answer to is, was there ever a fully syncing JavaScript node? Were you able to keep up at any point?
+
+**[11:43] SPEAKER_01:** Yes. Like so yes, we did have a syncing full node that worked for a little bit, but yeah, it was difficult. I still like it. I think it's doable today.
+
+**[11:59] SPEAKER_00:** Right.
+
+**[12:00] SPEAKER_01:** It's actually not like that. It's not that bad. I think the thing that, you know, that sort of didn't become our focus though, because it was just like not a huge demand for that.
+
+**[12:15] SPEAKER_00:** Right.
+
+**[12:16] SPEAKER_01:** Like, you know, everything else is going to go a lot faster. We were interested in the time of trying to embed a client in a browser.
+
+**[12:27] SPEAKER_00:** Yeah.
+
+**[12:29] SPEAKER_01:** Which is now possible.
+
+**[12:30] SPEAKER_00:** Right.
+
+**[12:30] SPEAKER_01:** But through the Helios project.
+
+**[12:33] SPEAKER_00:** Right, yeah. So what's that? I'm sorry, I don't know about Helios.
+
+**[12:38] SPEAKER_01:** Oh, it's a light client from ParityTech.
+
+**[12:42] SPEAKER_00:** Oh, right.
+
+**[12:43] SPEAKER_01:** They founded it, it's in Rust.
+
+**[12:44] SPEAKER_00:** Okay.
+
+**[12:45] SPEAKER_01:** And they compile it to WASM.
+
+**[12:47] SPEAKER_00:** Right.
+
+**[12:49] SPEAKER_01:** And it, you know okay, it's kind of cheesy, right. It just makes RPC requests, but it verifies the Merkle proofs and it verifies consensus.
+
+**[12:58] SPEAKER_00:** Right.
+
+**[12:58] SPEAKER_01:** So, yeah, it doesn't do the full thing, right. But you know, if, since I would say it's like a light client, it's definitely a light client that, you know, you have proof of the consensus is correct. And then you have, you know, you pull states that's verified from third party RPCs.
+
+**[13:17] SPEAKER_00:** Right.
+
+**[13:21] SPEAKER_01:** It's all right.
+
+**[13:22] SPEAKER_00:** Yeah. And so you attended Devcon0 in Berlin in November 2014.
+
+**[13:30] SPEAKER_01:** Yes.
+
+**[13:31] SPEAKER_00:** So how was that?
+
+**[13:32] SPEAKER_01:** That was really cool. It was my first time leaving the US. No, not quite. It was my first time flying over the ocean.
+
+**[13:40] SPEAKER_00:** Right.
+
+**[13:41] SPEAKER_01:** I'd been in Canada.
+
+**[13:42] SPEAKER_00:** Oh, yes, nice.
+
+**[13:44] SPEAKER_01:** Right. And saw the Niagara Falls and stuff. But yeah, so it's first time in Europe, so I was super excited. And yeah, I stayed in a big Airbnb with Juan Benet and Vitalik.
+
+**[13:58] SPEAKER_00:** Right.
+
+**[13:59] SPEAKER_01:** I think Vlad was in the Airbnb as well. It was super cool. Just, you know, see everyone for the first time, meet up and yeah.
+
+**[14:06] SPEAKER_00:** Right.
+
+**[14:10] SPEAKER_00:** Because there are a good chunk of people there. I was trying to count, I think, you know, 40 to 50, I think is about the number that were there. Pretty much everyone who was working on things. I was looking through. I don't think I could spot really anyone who was still involved, who wasn't there with maybe the yeah, Anthony Di Iorio wasn't there and he didn't technically leave until the end of 2015, but he was little involved.
+
+**[14:44] SPEAKER_01:** Yeah, I don't have well, actually I had a small contact with Anthony, but yeah, I never met him in I don't think I've ever met him in real life. I know he looks like though, right?
+
+**[14:54] SPEAKER_00:** Yeah, I have a few times. Hoping to talk to him soon.
+
+**[14:57] SPEAKER_01:** Oh, nice.
+
+**[14:59] SPEAKER_00:** But yeah, from there are missing videos from Devcon0, which I'm still looking for. There's 10 of them on the playlist on YouTube. There's one further which didn't go in the playlist, but is on there. But there seem to be about 10 missing sessions in there. Can you remember, did you talk at Devcon0?
+
+**[15:22] SPEAKER_01:** Was there a I did, yeah. And I gave a big presentation. Oh, big. Had my slides printed off. I gave a talk on ethereumjs and how I architected it. Yeah.
+
+**[15:39] SPEAKER_00:** So I think that that video is currently lost and I hope to recover.
+
+**[15:44] SPEAKER_01:** May have never got recorded. I don't know.
+
+**[15:46] SPEAKER_00:** I think they all did.
+
+**[15:48] SPEAKER_01:** Okay.
+
+**[15:49] SPEAKER_00:** And the other thing Tex was saying was that he did interviews with nearly everyone as well. Can you remember, did you talk to Tex? Did he go off into some back room and do an interview with him?
+
+**[15:59] SPEAKER_01:** I do not remember that.
+
+**[16:01] SPEAKER_00:** No.
+
+**[16:02] SPEAKER_01:** I remember Tex though. Yeah. And he's still around.
+
+**[16:05] SPEAKER_00:** Absolutely. Yeah. So, yeah, he was one of the earlier interviewees. Yeah. I've known Tex for a long time and it was funny because, you know, he had the water cooler channel. The Skype water cooler.
+
+**[16:18] SPEAKER_01:** Yes.
+
+**[16:19] SPEAKER_00:** So when I joined the EF, you know, I joined the EF channel and the water cooler and I thought they were both, you know, like foundation things, but it wasn't. It's basically Tex's control room. So then you got a bunch of sort of EF or people outside. It was a broader group. Skype are about to delete all their data, by the way. Okay. But you can request a download. So if you want to do that, like, do it fast.
+
+**[16:51] SPEAKER_01:** I don't have access to my Skype account anymore.
+
+**[16:55] SPEAKER_00:** Well, I didn't I mean, you can just log in and do a password recovery thing and then you can request it anyway. So I'm hoping to recover mine and maybe there's some interesting, you know, tidbits in that water cooler channel.
+
+**[17:09] SPEAKER_01:** Yeah, definitely. That'd be interesting.
+
+**[17:11] SPEAKER_00:** Yeah. So then, you know, I guess on into 2015 and through all the POCs, were you generally just, you know, continuing to maintain that as new features and changes came in through the POCs?
+
+**[17:28] SPEAKER_01:** Yeah, so we did. A lot of time was spent on the virtual machine, as you can imagine. That's sort of the largest one of the larger components. I also was working on networking.
+
+**[17:42] SPEAKER_00:** Right.
+
+**[17:42] SPEAKER_01:** So ethereumjs was a smaller team than everyone else.
+
+**[17:46] SPEAKER_00:** Yes.
+
+**[17:47] SPEAKER_01:** So we always lagged behind a bit. But yep, the networking protocols, our RLPx went through several iterations and then the virtual machine went through several iterations. We contributed to the testing.
+
+**[18:08] SPEAKER_00:** Right.
+
+**[18:11] SPEAKER_01:** And yeah, that was our main focus.
+
+**[18:16] SPEAKER_00:** Right. So, yeah, more about tooling use versus straight consensus client. Because there are many ethereumjs repos and components.
+
+**[18:30] SPEAKER_01:** Yeah. So the original architecture and it doesn't exist this way anymore. It's been merged into a monorepo. But originally it was a bunch of small modules. It still is a bunch of small modules, but it's a monorepo. It's much more sensible.
+
+**[18:44] SPEAKER_00:** Yes.
+
+**[18:45] SPEAKER_01:** But at that time, yeah, small repos for everything. And yeah, the focus was on building reusable components. So the most widely used component or most widely used module was ethereumjs-tx.
+
+**[19:04] SPEAKER_00:** Right.
+
+**[19:04] SPEAKER_01:** Used for creating and signing transactions.
+
+**[19:07] SPEAKER_00:** Right.
+
+**[19:08] SPEAKER_01:** So wallets such as MetaMask would use that internally to construct and sign a transaction. Then we had everything broken out. So RLP for serialization, the networking libraries, the virtual machine proper, some of the high level ones. The fun thing about ethereumjs was that I tried to make these modules very approachable and easy to use. So people did stuff like write a DHT scraper with it to see all the nodes, see what version they're running and things of that nature.
+
+**[19:54] SPEAKER_00:** Yeah, great. So do you have memories of launch day? Where were you on that day? How did that play out?
+
+**[20:05] SPEAKER_01:** Yeah, that was just like I think I was hacking away somewhere. I don't think I was anywhere special though. It's just sort of like another day for me.
+
+**[20:13] SPEAKER_00:** Right. You weren't in a room with people?
+
+**[20:16] SPEAKER_01:** No.
+
+**[20:16] SPEAKER_00:** Watching the screen with bated breath?
+
+**[20:19] SPEAKER_01:** No, no, I wasn't. It wasn't really yeah, I was just like, yeah, I'll just keep coding, you know, type of thing.
+
+**[20:25] SPEAKER_00:** Because there were a bunch of them were in the Berlin office together. There's a few photos of that.
+
+**[20:31] SPEAKER_01:** Yeah, I wasn't there in the Berlin office for that, unfortunately. I don't remember where I was, but yeah.
+
+**[20:38] SPEAKER_00:** Did you do any mining at any point?
+
+**[20:44] SPEAKER_01:** No, no. I was too nomadic. No, man.
+
+**[20:48] SPEAKER_00:** You haven't got the place to put the hardware.
+
+**[20:50] SPEAKER_01:** Yes. I never had a storage place for it.
+
+**[20:54] SPEAKER_00:** No. So then I guess, you know, through 2015, probably the next big piece was Devcon1. Did you attend Devcon1 in London?
+
+**[21:03] SPEAKER_01:** Yeah, London. I slept in a closet.
+
+**[21:05] SPEAKER_00:** That's my big Harry Potter memory from Devcon1.
+
+**[21:07] SPEAKER_01:** Yeah. I also gave a talk at Devcon1.
+
+**[21:14] SPEAKER_00:** Right.
+
+**[21:15] SPEAKER_01:** Also on ethereumjs, surprisingly.
+
+**[21:17] SPEAKER_00:** Right. So I mean, something somebody pointed out recently was like, if you look at the talks at Devcon1, it's like everything. Like there were so many different talks on so many different ideas and concepts, many of which foreshadowing things which are pretty big today, but probably nearly all of it was like 10 years too early.
+
+**[21:39] SPEAKER_01:** Yeah, exactly. We had a lot of there's just so many layers that needed to be built. Obviously when you start off, you see this thing I can do this. You don't fully understand all the layers that need to be created for that. That's a hard problem though. And I think we're still probably catching up to some of the original use cases that were envisioned.
+
+**[22:03] SPEAKER_00:** I was mentioning this to someone last night and he was saying, I think it's maybe another five or ten years from here before, you know, all of this stuff is in a viable kind of state. It's a lot more work than perhaps we envisaged at the start.
+
+**[22:23] SPEAKER_01:** Yeah, it sounds so easy when you start, but yeah, it is hard.
+
+**[22:27] SPEAKER_00:** Zolt was saying, I think when he joined the Geth team, he, you know, he was thinking this would, you know, like be 6 months, 12 months kind of thing to work on slightly longer, I guess. And yeah, he was, he asked Jeff, so, you know, how long do you think, you know, for all of these pieces? You know, Alethzero and Mix and Mist and Proof of Stake and sharding. And Jeff said, maybe about seven months or a little more.
+
+**[23:00] SPEAKER_01:** That's hilarious.
+
+**[23:01] SPEAKER_00:** So it was a little more.
+
+**[23:03] SPEAKER_01:** Yeah, slightly. A little bit more.
+
+**[23:06] SPEAKER_00:** I mean I had that same delusion because the very first thing I was doing was doing ARM Linux cross builds of the C++ client to try and run it on my smartwatch. Really with the thought that light client was close. Right. So just do the porting of the full clients and then the LES support will drop in in a few months and we can run a full node or a good enough light load node on a watch or everywhere. It's just like this is going to be everywhere, right? Every computing device, every router, it'll just pop in. It'll just be another protocol like TCP/IP. It'll be in the Linux kernel, just be like another thing, another service.
+
+**[23:50] SPEAKER_01:** It definitely has a ways to go before Linus merges that.
+
+**[23:54] SPEAKER_00:** Yes, I think yep.
+
+**[23:58] SPEAKER_01:** So I would still like I think it would be really cool though if someone built like a file system interface for Ethereum where like, you know, you could like CD into a folder with all the blocks and you know, CD into a particular block and see a list of transactions, etc. You know, kind of like a Plan 9, like.
+
+**[24:26] SPEAKER_00:** So you did a talk on this theme in Seattle. There was a meetup with yourselves, like the, like Kenny Rowe, some of the DAppSys people. I think Dan Finlay as well.
+
+**[24:41] SPEAKER_01:** Yeah, I think Dan Finlay was there. Juan from IPFS was definitely there.
+
+**[24:46] SPEAKER_00:** Yes, he was.
+
+**[24:46] SPEAKER_01:** I think David Diaz was there.
+
+**[24:49] SPEAKER_00:** Yeah, Into the Merkle Forest was one of the talks and I think yours was like Planetary OS.
+
+**[24:54] SPEAKER_01:** Yeah. Interplanetary Operating System.
+
+**[24:58] SPEAKER_00:** There we go.
+
+**[24:59] SPEAKER_01:** It was a fun talk.
+
+**[25:01] SPEAKER_00:** That's it. Merkle Computing.
+
+**[25:02] SPEAKER_01:** Yeah.
+
+**[25:02] SPEAKER_00:** Can still happen.
+
+**[25:04] SPEAKER_01:** Yeah. And there's no, like, technical reason, like you can't do those things. It's just, you know, layers need to be built.
+
+**[25:15] SPEAKER_00:** Yeah, absolutely. So we're getting the Oscars style music coming on. I'm going to have to have a wrap up. I did intend to talk about eWASM and things, but maybe that's for another time.
+
+**[25:28] SPEAKER_01:** Sounds good.
+
+**[25:29] SPEAKER_00:** Okay, so, yeah, we're up to the end of 2015.
+
+**[25:32] SPEAKER_01:** Nice.
+
+**[25:33] SPEAKER_00:** Okay, thanks so much, man.
+
+**[25:34] SPEAKER_01:** Yep. Thank you, Bob. Oh, wow.

--- a/scripts/process_all.sh
+++ b/scripts/process_all.sh
@@ -42,7 +42,7 @@ while [[ $# -gt 0 ]]; do
             echo "                           Default: whisperx"
             echo ""
   echo "  --processors <list>      Comma-separated AI post-processors"
-  echo "                           (opus, gemini, grok)"
+  echo "                           (opus, gemini, grok, qwen)"
             echo "                           Default: opus (Claude Opus 4.6)"
             echo ""
             echo "Examples:"

--- a/scripts/process_single.sh
+++ b/scripts/process_single.sh
@@ -20,7 +20,7 @@ if [ $# -eq 0 ]; then
     echo "  --transcribers <list>       Comma-separated transcription services"
     echo "                              (whisperx, whisperx-cloud, assemblyai)"
   echo "  --processors <list>         Comma-separated AI post-processors"
-  echo "                              (opus, gemini, grok)"
+  echo "                              (opus, gemini, grok, qwen)"
     echo ""
     echo "Optional:"
     echo "  --batch-size <n>            Batch size for WhisperX (default: 16 GPU, 8 CPU)"

--- a/scripts/process_single_post_process.py
+++ b/scripts/process_single_post_process.py
@@ -2,7 +2,7 @@
 """
 AI transcript post-processor for Ethereum/blockchain content.
 Batch process transcripts with multiple AI providers via OpenRouter.
-Supports: opus, gemini, grok (hosted) and local models via ollama.
+Supports: opus, gemini, grok, qwen (hosted) and local models via ollama.
 
 All models are accessed through OpenRouter (https://openrouter.ai) with a single API key.
 """
@@ -21,7 +21,7 @@ from common import (Colors, success, failure, skip, validate_api_key,
 # ============================================================================
 # Model Configuration: Hosted (OpenRouter) + Local (ollama)
 # ============================================================================
-# 3 hosted models via OpenRouter. 5 local options for 48GB (dual 3090s).
+# 4 hosted models via OpenRouter. 5 local options for 48GB (dual 3090s).
 #
 # HOSTED MODELS (OpenRouter):
 # ┌───────────┬─────────────────────┬───────────────────────────────────┬─────────┐
@@ -30,6 +30,7 @@ from common import (Colors, success, failure, skip, validate_api_key,
 # │ opus      │ Claude Opus 4.6     │ anthropic/claude-opus-4.6         │ 1M      │
 # │ gemini    │ Gemini 3.1 Pro      │ google/gemini-3.1-pro-preview     │ 1M      │
 # │ grok      │ Grok 4              │ x-ai/grok-4                       │ 256K    │
+# │ qwen      │ Qwen3.5 Plus        │ qwen/qwen3.5-plus-02-15           │ 1M      │
 # └───────────┴─────────────────────┴───────────────────────────────────┴─────────┘
 #
 # LOCAL MODELS (ollama, fit on 48GB):
@@ -50,6 +51,7 @@ OPENROUTER_MODELS = {
     'opus': 'anthropic/claude-opus-4.6',           # Claude Opus 4.6 - 1M context
     'gemini': 'google/gemini-3.1-pro-preview',     # Gemini 3.1 Pro - 1M context
     'grok': 'x-ai/grok-4',                         # Grok 4 - 256K context
+    'qwen': 'qwen/qwen3.5-plus-02-15',            # Qwen3.5 Plus - 1M context
 }
 
 # Max output tokens per model (some models need higher limits)
@@ -57,6 +59,7 @@ OPENROUTER_MAX_TOKENS = {
     'opus': 128000,     # Opus 4.6 supports 128K output
     'gemini': 64000,    # Gemini supports 64K output
     'grok': 32768,      # Grok uses internal reasoning, needs more tokens
+    'qwen': 64000,      # Qwen3.5 Plus supports large output
     'default': 8192,    # Default for others
 }
 
@@ -73,7 +76,7 @@ LOCAL_MODELS = {
 
 # Models that require OpenRouter (no local option for 48GB)
 HOSTED_ONLY_MODELS = {
-    'opus', 'gemini', 'grok',
+    'opus', 'gemini', 'grok', 'qwen',
 }
 
 # Direct API endpoints (bypass OpenRouter for specific providers)
@@ -829,7 +832,7 @@ def main():
     
     parser.add_argument("transcripts", nargs='+', help="Transcript file path(s)")
     parser.add_argument("--processors", required=True,
-                       help="Comma-separated list of processors. Hosted: opus,gemini,grok. Local-only: glm,deepseek-local,qwen-local,mistral-local,llama-local")
+                       help="Comma-separated list of processors. Hosted: opus,gemini,grok,qwen. Local-only: glm,deepseek-local,qwen-local,mistral-local,llama-local")
     parser.add_argument("--mode", choices=['hosted', 'local'], default='hosted',
                        help="Run models via OpenRouter API (hosted, default) or locally via ollama (local)")
     parser.add_argument("--parallel", type=int, default=0, metavar='N',
@@ -842,7 +845,7 @@ def main():
     # All valid processor names (hosted + local-only)
     valid_processors = {
         # Hosted (OpenRouter)
-        'opus', 'gemini', 'grok',
+        'opus', 'gemini', 'grok', 'qwen',
         # Local-only (ollama) - models that fit on 48GB
         'glm', 'deepseek-local', 'qwen-local', 'mistral-local', 'llama-local',
     }

--- a/scripts/process_video.sh
+++ b/scripts/process_video.sh
@@ -47,7 +47,7 @@ usage() {
     echo "  --transcriber <name>   Transcription service (default: whisperx)"
     echo "                         Options: whisperx, whisperx-cloud, assemblyai"
     echo "  --processor <name>     AI post-processor (optional)"
-    echo "                         Options: opus, gemini, grok"
+    echo "                         Options: opus, gemini, grok, qwen"
     echo "  --force-cpu            Force CPU mode for WhisperX"
     echo "  --title <text>         Title overlay at top of screen"
     echo ""

--- a/scripts/test_ai_providers.py
+++ b/scripts/test_ai_providers.py
@@ -17,6 +17,7 @@ OPENROUTER_MODELS = {
     'opus': ('anthropic/claude-opus-4.6', 'Claude Opus 4.6'),
     'gemini': ('google/gemini-3.1-pro-preview', 'Gemini 3.1 Pro'),
     'grok': ('x-ai/grok-4', 'Grok 4'),
+    'qwen': ('qwen/qwen3.5-plus-02-15', 'Qwen3.5 Plus'),
 }
 
 # Local model mapping (models that fit on 48GB dual 3090s)

--- a/scripts/test_context_limits.py
+++ b/scripts/test_context_limits.py
@@ -76,6 +76,13 @@ OPENROUTER_MODELS = {
         'advertised': '256,000 tokens',
         'test_sizes': [10000, 50000, 100000, 150000, 200000, 256000],
     },
+    'qwen': {
+        'model_id': 'qwen/qwen3.5-plus-02-15',
+        'display_name': 'Qwen3.5 Plus',
+        'provider': 'Alibaba',
+        'advertised': '1,000,000 tokens',
+        'test_sizes': [10000, 50000, 100000, 200000, 500000, 1000000],
+    },
 }
 
 # Model quality priority for recommendations
@@ -83,6 +90,7 @@ MODEL_PRIORITY = {
     'anthropic/claude-opus-4.6': 100,
     'x-ai/grok-4': 95,
     'google/gemini-3.1-pro-preview': 90,
+    'qwen/qwen3.5-plus-02-15': 85,
 }
 
 

--- a/scripts/transcript_to_srt.py
+++ b/scripts/transcript_to_srt.py
@@ -248,7 +248,7 @@ def load_word_timing(filepath):
         project_root / 'intermediates' / base_name / f"{base_name}_assemblyai_words.json",
         project_root / 'intermediates' / base_name / f"{base_name}_whisperx_words.json",
         project_root / 'intermediates' / base_name / f"{base_name}_whisperx-cloud_words.json",
-        filepath.parent / f"{filepath.stem.replace('_opus', '').replace('_gemini', '').replace('_grok', '')}_words.json",
+        filepath.parent / f"{filepath.stem.replace('_opus', '').replace('_gemini', '').replace('_grok', '').replace('_qwen', '')}_words.json",
     ]
 
     for json_path in json_patterns:


### PR DESCRIPTION
## Summary
- Added **Qwen3.5 Plus** (`qwen/qwen3.5-plus-02-15`) as a fourth hosted processor via OpenRouter
- 397B MoE model (17B active), 1M context window, open weights
- Released Feb 17, 2026 by Alibaba

## Test results
Tested on episode012-martin-becze (25 min, AssemblyAI base):
| Processor | Words | Lines | Status |
|-----------|-------|-------|--------|
| gemini | 4,093 | 384 | Tier 1 |
| grok | 4,074 | 378 | Tier 1 |
| **qwen** | **3,977** | **364** | **Tier 1** |
| opus | 3,850 | 382 | Tier 1 |

Complete coverage, good formatting, competitive quality.

## Files changed
- `process_single_post_process.py` — Added qwen to OPENROUTER_MODELS, MAX_TOKENS, HOSTED_ONLY, valid_processors
- `test_ai_providers.py`, `test_context_limits.py` — Added qwen entries
- `transcript_to_srt.py` — Added qwen to processor stripping
- All docs and shell scripts updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)